### PR TITLE
Change confusing instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,21 +27,17 @@ Additional links about Oklab:
 ## Development
 
 To run a local copy for development:
+1. Install Node.js and pnpm
+   - manually: ([`Node.js`](https://nodejs.org/), [`pnpm`](https://pnpm.io/installation))
+   - or with [`asdf`](https://github.com/asdf-vm/asdf)
 
-1. Install [`asdf`](https://github.com/asdf-vm/asdf).
-2. Install Node.js and pnpm by `asdf` or manually:
-
-   ```sh
-   asdf install
-   ```
-
-3. Install dependencies:
+2. Install dependencies:
 
    ```sh
    pnpm install
    ```
 
-4. Run local server:
+3. Run local server:
 
    ```sh
    pnpm start

--- a/README.md
+++ b/README.md
@@ -27,9 +27,11 @@ Additional links about Oklab:
 ## Development
 
 To run a local copy for development:
-1. Install Node.js and pnpm
-   - manually: ([`Node.js`](https://nodejs.org/), [`pnpm`](https://pnpm.io/installation))
-   - or with [`asdf`](https://github.com/asdf-vm/asdf)
+1. Install correct versions of `Node.js` and `pnpm`. There are two ways:
+	1. With `asdf` version manager:
+		1. Install [`asdf`](https://github.com/asdf-vm/asdf) and asdf plugins for `Node.js` and `pnpm`
+		2. Run `asdf install`
+	2. Manually (check needed versions in `.tool-versions`)
 
 2. Install dependencies:
 


### PR DESCRIPTION
Instructions in README wasn't clear and understandable about what the project needs.
There was a confusing feeling that `asdf` is needed for this project, also because there are 2 first points about that.
But basically it's optional and we need what `asdf` could give to us.

Also, second point is pointless at all
2. Install Node.js and pnpm by `asdf` or manually:

   ```sh
   asdf install
   ```
   
There are completely different ways how to install `asdf` and also installing plugins and environment path variables, so the command `asdf install` is useless and confusing, as I see.
