### PR TITLE
Fix typo `okclch.com`

### DIFF
--- a/view/desc/index.pug
+++ b/view/desc/index.pug
@@ -12,8 +12,8 @@
       But Lab and LCH have [hue shift] on chroma changes. [Oklab and OKLCH]
       were created to solve this problem.
 
-      [hue shift]: https://lch.okclch.com/#35,90,297,100
-      [Oklab and OKLCH]: https://okclch.com/#45.8,0.143,285.98,100
+      [hue shift]: https://lch.oklch.com/#35,90,297,100
+      [Oklab and OKLCH]: https://oklch.com/#45.8,0.143,285.98,100
       [Unlike HSL]: https://wildbit.com/blog/accessible-palette-stop-using-hsl-for-color-systems
   else
     :markdown-it


### PR DESCRIPTION
I noticed there's a typo in the links in the description.