### PR TITLE
Fixes for #57: Prevent selection on axis and restrict drag area to canvas only

### DIFF
--- a/lib/math.ts
+++ b/lib/math.ts
@@ -1,0 +1,3 @@
+export function clamp(val: number, min: number, max: number) {
+  return Math.min(Math.max(min, val), max)
+}

--- a/view/chart/index.css
+++ b/view/chart/index.css
@@ -8,7 +8,6 @@ body {
   position: relative;
   box-sizing: border-box;
   height: 100%;
-  cursor: pointer;
   border: var(--unavailable-border);
   border-width: 1px 0;
 
@@ -72,6 +71,7 @@ body {
   font-size: 12px;
   text-align: center;
   text-transform: uppercase;
+  user-select: none;
   opacity: 50%;
 
   @nest .chart_line.is-x & {
@@ -91,5 +91,6 @@ body {
   left: 0;
   width: 100%;
   height: calc(100% + 2px);
+  cursor: pointer;
   image-rendering: crisp-edges;
 }


### PR DESCRIPTION
Hey! I made a few changes to fix the things outlines in #57 .

Style changes were made to prevent selection of axis labels.

Event handlers are attached to the canvas elements themselves and not the surrounding div. This should limit the drag area to the canvas only.

All that said, I did make a few changes which may be beyond the scope desired here. I've made a few drag and drop type things in the past and typically added event handlers for mouseup and mousemove to the document itself. The reasons I've done this in the past are:

1. It allows the user to drag past the bounds of the intended drag area, which seems to be expected in some cases by the user
2. It de-activates the drag on the canvas regardless of where the user mouseups. This way you dont really get stuck in the "still dragging" state.

These changes required additional changes to how the onSelect handler is used. A clamp function is also required to contain the axis on the charts, since you can now drag in the negative direction and beyond the canvas bounds.

Hope this helps!

Let me know if there's anything I can change to get this in!

https://user-images.githubusercontent.com/9381099/210035966-52336995-0944-40a7-b1a4-9cb5759c85d3.mp4

