### PR TITLE
Fix spelling of "accessibility"

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ OKLCH is a new way to encode colors (like hex, RGBA, or HSL):
 - [Unlike HSL], OKLCH always has predictable contrast
   after color transformation.
 - In contrast [with LCH and Lab], no [hue shift] on chroma changes.
-- Provides great a11y on palette generation.
+- Provides great accessibility on palette generation.
 
 Additional links about Oklab and OKLCH:
 

--- a/view/desc/index.pug
+++ b/view/desc/index.pug
@@ -24,7 +24,7 @@
         (P3, Rec. 2020, and beyond).
       - [Unlike HSL], OKLCH always has predictable contrast
         after color transformation.
-      - Provides great a11y on palette generation.
+      - Provides great accessibility on palette generation.
 
       Read [our OKLCH guide](https://evilmartians.com/chronicles/oklch-in-css-why-quit-rgb-hsl).
 


### PR DESCRIPTION
There's no space constraints on the site that mean an abbreviation is necessary, and "a11y" has both accessibility issues (e.g. screen readers) and is industry jargon where the meaning is difficult to infer.

Just write out the full word "accessibility".