### PR TITLE
Convert grid to 2 letters

### DIFF
--- a/view/layout/index.css
+++ b/view/layout/index.css
@@ -7,14 +7,14 @@
 
   @media (width < 830px) {
     grid-template:
-      "T"
-      "L"
-      "C"
-      "H"
-      "A"
-      "M"
-      "P"
-      "S";
+      "Ti"
+      "Lc"
+      "CC"
+      "HC"
+      "AC"
+      "Ma"
+      "Pr"
+      "So";
     padding-bottom: 450px;
 
     @nest body.is-main-collapsed & {
@@ -24,29 +24,29 @@
 
   @media (width >= 830px) and (width < 1230px) {
     grid-template:
-      "T T"
-      "M M"
-      "L C"
-      "A H"
-      "P H";
+      "Ti Ti"
+      "Ma Ma"
+      "LC CC"
+      "AC HC"
+      "Pr HC";
   }
 
   @media (width >= 1230px) {
     grid-template:
-      "T T T"
-      "M L C"
-      "M A H"
-      "M P H"
-      "M . .";
+      "Ti Ti Ti"
+      "Ma LC CC"
+      "Ma AC HC"
+      "Ma Pr HC"
+      "Ma . .";
   }
 }
 
 .layout_title {
-  grid-area: T;
+  grid-area: Ti;
 }
 
 .layout_main {
-  grid-area: M;
+  grid-area: Ma;
 
   @media (width >= 830px) and (width < 1230px) {
     display: flex;
@@ -54,23 +54,23 @@
 }
 
 .layout_l {
-  grid-area: L;
+  grid-area: LC;
 }
 
 .layout_c {
-  grid-area: C;
+  grid-area: CC;
 }
 
 .layout_h {
-  grid-area: H;
+  grid-area: HC;
 }
 
 .layout_a {
-  grid-area: A;
+  grid-area: AC;
 }
 
 .layout_prefs {
-  grid-area: P;
+  grid-area: Pr;
 }
 
 .layout_panel {
@@ -96,6 +96,6 @@
   }
 
   @media (width < 830px) {
-    grid-area: "S";
+    grid-area: "So";
   }
 }

--- a/view/layout/index.css
+++ b/view/layout/index.css
@@ -7,14 +7,14 @@
 
   @media (width < 830px) {
     grid-template:
-      "Ti"
-      "Lc"
-      "CC"
-      "HC"
-      "AC"
-      "Ma"
-      "Pr"
-      "So";
+      "title"
+      "ltness"
+      "chroma"
+      "hue"
+      "alpha"
+      "main"
+      "prefs"
+      "source";
     padding-bottom: 450px;
 
     @nest body.is-main-collapsed & {
@@ -24,29 +24,29 @@
 
   @media (width >= 830px) and (width < 1230px) {
     grid-template:
-      "Ti Ti"
-      "Ma Ma"
-      "LC CC"
-      "AC HC"
-      "Pr HC";
+      "title title"
+      "main main"
+      "ltness chroma"
+      "alpha hue"
+      "prefs hue";
   }
 
   @media (width >= 1230px) {
     grid-template:
-      "Ti Ti Ti"
-      "Ma LC CC"
-      "Ma AC HC"
-      "Ma Pr HC"
-      "Ma . .";
+      "title title title"
+      "main ltness chroma"
+      "main alpha hue"
+      "main prefs hue"
+      "main . .";
   }
 }
 
 .layout_title {
-  grid-area: Ti;
+  grid-area: title;
 }
 
 .layout_main {
-  grid-area: Ma;
+  grid-area: main;
 
   @media (width >= 830px) and (width < 1230px) {
     display: flex;
@@ -54,23 +54,23 @@
 }
 
 .layout_l {
-  grid-area: LC;
+  grid-area: ltness;
 }
 
 .layout_c {
-  grid-area: CC;
+  grid-area: chroma;
 }
 
 .layout_h {
-  grid-area: HC;
+  grid-area: hue;
 }
 
 .layout_a {
-  grid-area: AC;
+  grid-area: alpha;
 }
 
 .layout_prefs {
-  grid-area: Pr;
+  grid-area: prefs;
 }
 
 .layout_panel {
@@ -96,6 +96,6 @@
   }
 
   @media (width < 830px) {
-    grid-area: "So";
+    grid-area: "source";
   }
 }


### PR DESCRIPTION
Solves #70 
I used two letters to define grid. It should be more than enough to add 3d space and even further features, if needed and leave css readable. But maybe at this point it would be more convenient to use while words or at least longer abbreviations.

I use capital letter and small letter where one word is implied i.e. Ma - main
And two capital letters where two words are implied i.e. HC - hue card/chart

Hope this convention is readable enough