### PR TITLE
Fix non-clickable chart lines 

### DIFF
--- a/view/chart/index.css
+++ b/view/chart/index.css
@@ -23,6 +23,7 @@ body {
   left: 0;
   width: 100%;
   height: calc(100% + 1px);
+  pointer-events: none;
 
   &.is-l.is-x {
     --chart-line-position: var(--chart-l);


### PR DESCRIPTION
Seems to be a bug, because nothing happens when user clicks on point where he released mouse(for example while not moving it)

https://user-images.githubusercontent.com/62726575/219884528-22c1cbe1-0b4a-4971-97cf-e6f5add85cc3.mp4

