### PR TITLE
Add tolerance to gamut check

### DIFF
--- a/config.js
+++ b/config.js
@@ -13,7 +13,9 @@ let config = {
   H_STEP: 0.45,
 
   ALPHA_MAX: 100,
-  ALPHA_STEP: 5
+  ALPHA_STEP: 5,
+
+  GAMUT_EPSILON: 1e-6
 }
 
 if (process.env.LCH) {

--- a/lib/colors.ts
+++ b/lib/colors.ts
@@ -3,7 +3,6 @@ import {
   formatRgb as formatRgbFast,
   parse as originParse,
   clampChroma,
-  displayable,
   modeRec2020,
   modeOklch,
   modeOklab,
@@ -29,16 +28,27 @@ useMode(modeOklab)
 useMode(modeHsl)
 useMode(modeLab)
 
-export const inRGB = displayable
-
-export function inP3(color: Color): boolean {
-  let { r, b, g } = p3(color)
-  return r >= 0 && r <= 1 && g >= 0 && g <= 1 && b >= 0 && b <= 1
+function inGamut(
+  convert: (color: Color) => Color,
+  color: Color,
+  epsilon: number
+): boolean {
+  let { r, g, b } = convert(color)
+  let min = 0 - epsilon
+  let max = 1 + epsilon
+  return r >= min && r <= max && g >= min && g <= max && b >= min && b <= max
 }
 
-export function inRec2020(color: Color): boolean {
-  let { r, b, g } = rec2020(color)
-  return r >= 0 && r <= 1 && g >= 0 && g <= 1 && b >= 0 && b <= 1
+export function inRGB(color: Color, epsilon: number = GAMUT_EPSILON): boolean {
+  return inGamut(rgb, color, epsilon)
+}
+
+export function inP3(color: Color, epsilon: number = GAMUT_EPSILON): boolean {
+  return inGamut(p3, color, epsilon)
+}
+
+export function inRec2020(color: Color, epsilon: number = GAMUT_EPSILON): boolean {
+  return inGamut(rec2020, color, epsilon)
 }
 
 export function build(l: number, c: number, h: number, alpha = 1): AnyLch {

--- a/types.d.ts
+++ b/types.d.ts
@@ -30,3 +30,4 @@ declare const H_MAX: number
 declare const H_STEP: number
 declare const ALPHA_MAX: number
 declare const ALPHA_STEP: number
+declare const GAMUT_EPSILON: number


### PR DESCRIPTION
Дает частичное улучшение ситуации с пограничными цветами.
В частности, перестали выпадать `rgb(0, 0, 255)` и `rgb(0, 255, 255)`.

Но часть проблем осталась:
1. Даже если в инпуте координаты не слетели, могут немного сползать линейки на диаграмме Lightness (например, у того же синего);
2. Остается проблема с фиолетовым `rgb(255, 0, 255)` -> `rgb(255, 2, 255)`.

Однако, насколько я выяснил, здесь причины уже не в проверке охвата — это от округления координат OKLch.