### PR TITLE
Shorten color conversions and speed up painting

### DIFF
--- a/lib/colors.ts
+++ b/lib/colors.ts
@@ -150,8 +150,11 @@ export enum Space {
   Out
 }
 
-function getProxyColor(color: Color): Color {
-  return COLOR_FN === 'oklch' ? rgb(color) : xyz65(color)
+let getProxyColor: (color: Color) => Color
+if (COLOR_FN === 'oklch') {
+  getProxyColor = rgb
+} else {
+  getProxyColor = xyz65
 }
 
 export function getSpace(color: Color): Space {

--- a/lib/colors.ts
+++ b/lib/colors.ts
@@ -6,6 +6,7 @@ import {
   modeRec2020,
   modeOklch,
   modeOklab,
+  modeXyz65,
   formatCss,
   useMode,
   modeRgb,
@@ -22,6 +23,7 @@ export type AnyLch = Lch | Oklch
 export let rec2020 = useMode(modeRec2020)
 export let oklch = useMode(modeOklch)
 export let oklab = useMode(modeOklab)
+export let xyz65 = useMode(modeXyz65)
 export let rgb = useMode(modeRgb)
 export let lch = useMode(modeLch)
 export let hsl = useMode(modeHsl)
@@ -148,12 +150,17 @@ export enum Space {
   Out
 }
 
+function getProxyColor(color: Color): Color {
+  return COLOR_FN === 'oklch' ? rgb(color) : xyz65(color)
+}
+
 export function getSpace(color: Color): Space {
-  if (inRGB(color)) {
+  let proxyColor = getProxyColor(color)
+  if (inRGB(proxyColor)) {
     return Space.sRGB
-  } else if (inP3(color)) {
+  } else if (inP3(proxyColor)) {
     return Space.P3
-  } else if (inRec2020(color)) {
+  } else if (inRec2020(proxyColor)) {
     return Space.Rec2020
   } else {
     return Space.Out
@@ -168,11 +175,12 @@ export function generateGetSpace(
 ): GetSpace {
   if (showP3 && showRec2020) {
     return color => {
-      if (inRGB(color)) {
+      let proxyColor = getProxyColor(color)
+      if (inRGB(proxyColor)) {
         return Space.sRGB
-      } else if (inP3(color)) {
+      } else if (inP3(proxyColor)) {
         return Space.P3
-      } else if (inRec2020(color)) {
+      } else if (inRec2020(proxyColor)) {
         return Space.Rec2020
       } else {
         return Space.Out
@@ -180,9 +188,10 @@ export function generateGetSpace(
     }
   } else if (showP3 && !showRec2020) {
     return color => {
-      if (inRGB(color)) {
+      let proxyColor = getProxyColor(color)
+      if (inRGB(proxyColor)) {
         return Space.sRGB
-      } else if (inP3(color)) {
+      } else if (inP3(proxyColor)) {
         return Space.P3
       } else {
         return Space.Out
@@ -190,9 +199,10 @@ export function generateGetSpace(
     }
   } else if (!showP3 && showRec2020) {
     return color => {
-      if (inRGB(color)) {
+      let proxyColor = getProxyColor(color)
+      if (inRGB(proxyColor)) {
         return Space.sRGB
-      } else if (inRec2020(color)) {
+      } else if (inRec2020(proxyColor)) {
         return Space.P3
       } else {
         return Space.Out
@@ -223,18 +233,19 @@ export function generateGetPixel(
     if (p3Support) {
       return (x, y) => {
         let color = getColor(x, y)
-        let colorP3 = p3(color)
+        let proxyColor = getProxyColor(color)
+        let colorP3 = p3(proxyColor)
         let pixel: Pixel = [
           Space.Out,
           Math.floor(255 * colorP3.r),
           Math.floor(255 * colorP3.g),
           Math.floor(255 * colorP3.b)
         ]
-        if (inRGB(color)) {
+        if (inRGB(proxyColor)) {
           pixel[0] = Space.sRGB
         } else if (inP3(colorP3)) {
           pixel[0] = Space.P3
-        } else if (inRec2020(color)) {
+        } else if (inRec2020(proxyColor)) {
           pixel[0] = Space.Rec2020
         }
         return pixel
@@ -242,7 +253,8 @@ export function generateGetPixel(
     } else {
       return (x, y) => {
         let color = getColor(x, y)
-        let colorSRGB = rgb(color)
+        let proxyColor = getProxyColor(color)
+        let colorSRGB = rgb(proxyColor)
         let pixel: Pixel = [
           Space.Out,
           Math.floor(255 * colorSRGB.r),
@@ -251,9 +263,9 @@ export function generateGetPixel(
         ]
         if (inRGB(colorSRGB)) {
           pixel[0] = Space.sRGB
-        } else if (inP3(color)) {
+        } else if (inP3(proxyColor)) {
           pixel[0] = Space.P3
-        } else if (inRec2020(color)) {
+        } else if (inRec2020(proxyColor)) {
           pixel[0] = Space.Rec2020
         }
         return pixel
@@ -263,14 +275,15 @@ export function generateGetPixel(
     if (p3Support) {
       return (x, y) => {
         let color = getColor(x, y)
-        let colorP3 = p3(color)
+        let proxyColor = getProxyColor(color)
+        let colorP3 = p3(proxyColor)
         let pixel: Pixel = [
           Space.Out,
           Math.floor(255 * colorP3.r),
           Math.floor(255 * colorP3.g),
           Math.floor(255 * colorP3.b)
         ]
-        if (inRGB(color)) {
+        if (inRGB(proxyColor)) {
           pixel[0] = Space.sRGB
         } else if (inP3(colorP3)) {
           pixel[0] = Space.P3
@@ -280,7 +293,8 @@ export function generateGetPixel(
     } else {
       return (x, y) => {
         let color = getColor(x, y)
-        let colorSRGB = rgb(color)
+        let proxyColor = getProxyColor(color)
+        let colorSRGB = rgb(proxyColor)
         let pixel: Pixel = [
           Space.Out,
           Math.floor(255 * colorSRGB.r),
@@ -289,7 +303,7 @@ export function generateGetPixel(
         ]
         if (inRGB(colorSRGB)) {
           pixel[0] = Space.sRGB
-        } else if (inP3(color)) {
+        } else if (inP3(proxyColor)) {
           pixel[0] = Space.P3
         }
         return pixel
@@ -299,16 +313,17 @@ export function generateGetPixel(
     if (p3Support) {
       return (x, y) => {
         let color = getColor(x, y)
-        let colorP3 = p3(color)
+        let proxyColor = getProxyColor(color)
+        let colorP3 = p3(proxyColor)
         let pixel: Pixel = [
           Space.Out,
           Math.floor(255 * colorP3.r),
           Math.floor(255 * colorP3.g),
           Math.floor(255 * colorP3.b)
         ]
-        if (inRGB(color)) {
+        if (inRGB(proxyColor)) {
           pixel[0] = Space.sRGB
-        } else if (inRec2020(color)) {
+        } else if (inRec2020(proxyColor)) {
           pixel[0] = Space.Rec2020
         }
         return pixel
@@ -316,7 +331,8 @@ export function generateGetPixel(
     } else {
       return (x, y) => {
         let color = getColor(x, y)
-        let colorSRGB = rgb(color)
+        let proxyColor = getProxyColor(color)
+        let colorSRGB = rgb(proxyColor)
         let pixel: Pixel = [
           Space.Out,
           Math.floor(255 * colorSRGB.r),
@@ -325,7 +341,7 @@ export function generateGetPixel(
         ]
         if (inRGB(colorSRGB)) {
           pixel[0] = Space.sRGB
-        } else if (inRec2020(color)) {
+        } else if (inRec2020(proxyColor)) {
           pixel[0] = Space.Rec2020
         }
         return pixel
@@ -334,14 +350,15 @@ export function generateGetPixel(
   } else if (p3Support) {
     return (x, y) => {
       let color = getColor(x, y)
-      let colorP3 = p3(color)
+      let proxyColor = getProxyColor(color)
+      let colorP3 = p3(proxyColor)
       let pixel: Pixel = [
         Space.Out,
         Math.floor(255 * colorP3.r),
         Math.floor(255 * colorP3.g),
         Math.floor(255 * colorP3.b)
       ]
-      if (inRGB(color)) {
+      if (inRGB(proxyColor)) {
         pixel[0] = Space.sRGB
       }
       return pixel

--- a/types.d.ts
+++ b/types.d.ts
@@ -73,6 +73,14 @@ declare module 'culori/fn' {
     alpha?: number
   }
 
+  export interface Xyz65 {
+    mode: 'xyz65'
+    x: number
+    y: number
+    z: number
+    alpha?: number
+  }
+
   export interface P3 {
     mode: 'p3'
     r: number
@@ -113,7 +121,7 @@ declare module 'culori/fn' {
   export function formatRgb(c: Color): string
   export function formatRgb(c: string): string | undefined
 
-  export type Color = Hsl | Lab | Lch | Oklab | Oklch | P3 | Rec2020 | Rgb
+  export type Color = Hsl | Lab | Lch | Oklab | Oklch | Xyz65 | P3 | Rec2020 | Rgb
   type Mode = Color['mode']
 
   export function clampChroma<C extends Color>(
@@ -143,6 +151,7 @@ declare module 'culori/fn' {
   export let modeLch: { mode: Lch['mode'] }
   export let modeOklab: { mode: Oklab['mode'] }
   export let modeOklch: { mode: Oklch['mode'] }
+  export let modeXyz65: { mode: Xyz65['mode'] }
   export let modeP3: { mode: P3['mode'] }
   export let modeRec2020: { mode: Rec2020['mode'] }
   export let modeRgb: { mode: Rgb['mode'] }
@@ -153,6 +162,7 @@ declare module 'culori/fn' {
     | typeof modeLch
     | typeof modeOklab
     | typeof modeOklch
+    | typeof modeXyz65
     | typeof modeP3
     | typeof modeRec2020
     | typeof modeRgb


### PR DESCRIPTION
Релизация #79.

В чистом виде функция `getSpace` используется буквально в одном месте, поэтому там не получить ни заметного влияния, ни стабильного бенчмарка.
Поэтому пришлось модифицировать `generateGetSpace` и `generateGetPixel`, которые вызываются много раз.

### Константа `COLOR_FN`

Посмотрел подробнее – оказалось, что практически всегда в функции передается `AnyLch`. То есть `COLOR_FN` использовать можно. Я вынес эту проверку в функцию `getProxyColor` (насколько я знаю, JIT умеет инлайнить такое).

Есть всего одно исключение, где в `getSpace` может попасть что-то другое:
https://github.com/evilmartians/oklch-picker/blob/16fce6f13ab8fb2c8e148767ae2d33a8ecffdd06/stores/current.ts#L194
Тут промежуточное преобразование может окажется лишним. Но во-первых, ключевое слово тут "может" – в некоторых случаях да, в некоторых нет. А во-вторых, там обрабатывается единичный цвет, поэтому на перфоманс не влияет. В остальных случаях rgb-цвета проверяются напрямую функциями `inRGB`/`inP3`.

Хотя, если хочется сделать красивее, можно подумать над рефакторингом с уточнением типов.

Вообще, если бы у Culori был прямой переход `OKLab->xyz65`, можно было бы вообще убрать условие и делать промежуточный цвет `xyz65` всегда. Но без прямой конвертации получается хуже.


### Перфоманс

Выигрыш есть и он тем заметнее, чем больше включено цветовых режимов.
Если включить всё, у меня по `Full paint` получается -30...35% в Хромиуме и -20...25% в FF.