### PR TITLE
Fix header hierarchy

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,8 +7,8 @@
   </head>
 
   <body class="is-loading">
-    <template data-type="pug" data-src="./view/fullmodel/index.pug" />
     <template data-type="pug" data-src="./view/layout/index.pug" />
+    <template data-type="pug" data-src="./view/fullmodel/index.pug" />
     <template data-type="pug" data-src="./view/benchmark/index.pug" />
   </body>
 </html>


### PR DESCRIPTION
### What's new?

There was a problem with the header hierarchy and the headers were like this:

```
H2 OKLCH 3D model
H1 OKLCH Color Picker & Converter
H2 Lightness
H2 Chroma
H2 Hue
H2 3D
H2 Alpha
```

And I corrected to this:

```
H1 OKLCH Color Picker & Converter
H2 Lightness
H2 Chroma
H2 Hue
H2 3D
H2 Alpha
H2 OKLCH 3D model
```

This problem was due to the fact that the full model used second-level headings and connected before the main content