### PR TITLE
Update styles for fullmodel

### DIFF
--- a/view/fullmodel/index.css
+++ b/view/fullmodel/index.css
@@ -3,9 +3,16 @@
   top: 0;
   left: 0;
   z-index: 10;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: space-between;
   width: 100%;
   height: 100%;
   padding-top: 12px;
+  padding-bottom: 36px;
+  overflow: hidden;
   background: var(--surface-3d);
 
   &.is-hidden {
@@ -36,21 +43,13 @@
 }
 
 .fullmodel_status {
-  position: absolute;
-  top: 50%;
-  left: 50%;
   font-size: 12px;
   color: var(--text-secondary);
-  transform: translate(-50%, -50%);
 }
 
 .fullmodel_note {
-  position: absolute;
-  bottom: 36px;
-  left: 50%;
   z-index: -2;
   font-size: 10px;
   line-height: 16px;
   color: var(--text-secondary);
-  transform: translateX(-50%);
 }


### PR DESCRIPTION
### What's new?

Update styles for fullmodel

1. It is not necessary to position all elements. Removed positioning of some elements with flexbox
2. Added `box-sizing: border-box;` because there was a vertical scroll due to the fact that before that I added `padding-top`. Height is `100% + padding-top` and I fixed it