### PR TITLE
Add data attribute for field

### DIFF
--- a/view/code/index.pug
+++ b/view/code/index.pug
@@ -6,7 +6,7 @@
 .code.is-rgb
   +field('hex/rgba CSS code', 'r', {
     type: 'text',
-    options: {
+    'data-options': {
       'hex/rgba': 'Auto hex/rgba',
       'hex': '',
       'rgb': '',
@@ -16,7 +16,7 @@
       'lab': '',
       'oklab': '',
     },
-    optionsLabel: 'Change format'
+    'data-optionsLabel': 'Change format'
   })
   .code_note.is-paste
     = `Paste HEX, RGBA, or HSL to convert to ${LCH ? 'LCH' : 'OKLCH'}`


### PR DESCRIPTION
### What's new?

You can't use custom attributes that HTML doesn't have. Because of this error in the validator. If you need to save some information, then you need to use the `data-*`

#### Before
![Screenshot from 2023-05-18 22-27-09](https://github.com/evilmartians/oklch-picker/assets/132574537/e5a144a3-028e-41d9-baa3-b0065e57b155)

### After
![Screenshot from 2023-05-18 22-27-23](https://github.com/evilmartians/oklch-picker/assets/132574537/7d7b59b6-ce5d-43c4-a64e-42d769977257)
