### PR TITLE
Add math to lch fields #74

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -8,7 +8,7 @@
       "!dist/*.webmanifest",
       "!dist/*.png"
     ],
-    "limit": "60 KB"
+    "limit": "65 KB"
   },
   {
     "name": "Base scripts to execute",

--- a/lib/math.ts
+++ b/lib/math.ts
@@ -1,0 +1,85 @@
+enum Priority {
+  Low = 1,
+  High = 2
+}
+let DefaultValue = 0
+
+type Operators = typeof operators
+let operators = {
+  '+': Priority.Low,
+  '-': Priority.Low,
+  '*': Priority.High,
+  '/': Priority.High
+}
+
+let operations = {
+  '+': (a: number, b: number) => a + b,
+  '-': (a: number, b: number) => b - a,
+  '*': (a: number, b: number) => a * b,
+  '/': (a: number, b: number) => b / a
+}
+
+export function parseValue(n: number | string): number {
+  if (typeof n === 'number') return n
+  let parsedValue = parseFloat(n)
+  return isNaN(parsedValue) ? DefaultValue : parsedValue
+}
+
+function toPostfix(str: string): string[] {
+  let stack: string[] = []
+  let result: string[] = []
+
+  for (let i = 0; i < str.length; i++) {
+    let current = str.charAt(i)
+
+    if (current in operators) {
+      if (stack.length === 0) {
+        stack.push(current)
+        continue
+      }
+
+      let topElement = stack[stack.length - 1] as keyof Operators
+      let currentPicked = current as keyof Operators
+
+      while (operators[topElement] <= operators[currentPicked]) {
+        result.push(stack.pop()!)
+      }
+      stack.push(current)
+    } else {
+      let isContinuedNumber = /^[\d.]+$/.test(str.charAt(i - 1))
+
+      if (i > 0 && isContinuedNumber) {
+        let last = result.length - 1
+        result[last] = result[last].concat(current)
+      } else {
+        result.push(current)
+      }
+    }
+  }
+
+  while (stack.length > 0) {
+    result.push(stack.pop()!)
+  }
+
+  return result
+}
+
+export function computeExpression(str: string): number {
+  if (!/[*+-/]/.test(str)) return parseValue(str)
+
+  let postfixOfExpression = toPostfix(str)
+  let stack: number[] = []
+
+  for (let ch of postfixOfExpression) {
+    if (ch in operations) {
+      let callback = operations[ch as keyof Operators]
+      stack.push(callback(stack.pop()!, stack.pop()!))
+    } else {
+      stack.push(parseValue(ch))
+    }
+  }
+
+  let result = stack.pop() ?? DefaultValue
+
+  return result
+}

--- a/lib/math.ts
+++ b/lib/math.ts
@@ -41,7 +41,10 @@ function toPostfix(str: string): string[] {
       let topElement = stack[stack.length - 1] as keyof Operators
       let currentPicked = current as keyof Operators
 
-      while (operators[topElement] <= operators[currentPicked]) {
+      while (
+        stack.length > 0 &&
+        operators[topElement] <= operators[currentPicked]
+      ) {
         result.push(stack.pop()!)
       }
       stack.push(current)

--- a/view/card/index.ts
+++ b/view/card/index.ts
@@ -3,7 +3,7 @@ import { showRec2020, showCharts } from '../../stores/settings.js'
 
 function initInput(type: 'l' | 'c' | 'h' | 'a'): HTMLInputElement {
   let card = document.querySelector<HTMLDivElement>(`.card.is-${type}`)!
-  let text = card.querySelector<HTMLInputElement>('[type=number]')!
+  let text = card.querySelector<HTMLInputElement>('[role=spinbutton]')!
 
   text.addEventListener('change', () => {
     current.setKey(type, parseFloat(text.value))

--- a/view/card/index.ts
+++ b/view/card/index.ts
@@ -1,12 +1,62 @@
+import type { SpinEvent } from '../field/index.js'
+
+import { computeExpression, parseValue } from '../../lib/math.js'
 import { current, onCurrentChange } from '../../stores/current.js'
 import { showRec2020, showCharts } from '../../stores/settings.js'
+import { clean } from '../../lib/colors.js'
+
+interface MetaSpinInput {
+  max: number
+  min: number
+  step: number
+}
+
+function getInputMeta(input: HTMLInputElement): MetaSpinInput {
+  return {
+    step: parseValue(input.getAttribute('step')!),
+    max: parseValue(input.getAttribute('aria-valuemax')!),
+    min: parseValue(input.getAttribute('aria-valuemin')!)
+  }
+}
 
 function initInput(type: 'l' | 'c' | 'h' | 'a'): HTMLInputElement {
   let card = document.querySelector<HTMLDivElement>(`.card.is-${type}`)!
   let text = card.querySelector<HTMLInputElement>('[role=spinbutton]')!
 
   text.addEventListener('change', () => {
-    current.setKey(type, parseFloat(text.value))
+    let { max, min } = getInputMeta(text)
+
+    let computedExpression = clean(
+      Math.max(min, Math.min(max, computeExpression(text.value)))
+    )
+
+    current.setKey(type, computedExpression)
+    text.setAttribute('aria-valuenow', String(computedExpression))
+  })
+
+  text.addEventListener('spin', e => {
+    let { max, min, step } = getInputMeta(text)
+
+    let value = computeExpression(text.value)
+
+    switch ((e as SpinEvent).detail.action) {
+      case 'increase':
+        value = Math.min(max, value + step)
+        break
+      case 'decrease':
+        value = Math.max(min, value - step)
+        break
+      case 'setMaximum':
+        value = max
+        break
+      case 'setMinimum':
+        value = min
+        break
+    }
+
+    let parsedValue = clean(value)
+    current.setKey(type, parsedValue)
+    text.setAttribute('aria-valuenow', String(parsedValue))
   })
 
   return text
@@ -37,5 +87,5 @@ showCharts.subscribe(show => {
 })
 
 showRec2020.subscribe(show => {
-  textC.max = String(show ? C_MAX_REC2020 : C_MAX)
+  textC.setAttribute('aria-valuemax', String(show ? C_MAX_REC2020 : C_MAX))
 })

--- a/view/card/mixin.pug
+++ b/view/card/mixin.pug
@@ -11,6 +11,8 @@ mixin card(type)
           role: 'spinbutton',
           'aria-valuemin': 0,
           'aria-valuemax': 100,
+          pattern: '^[0-9+\/*\-\.]+$',
+          inputmode: 'decimal',
           step: L_STEP
         })
       .card_chart
@@ -24,7 +26,9 @@ mixin card(type)
         +field('C', 'c', {
           type: 'text',
           role: 'spinbutton',
+          pattern: '^[0-9+\/*\-\.]+$',
           'aria-valuemin': 0,
+          inputmode: 'decimal',
           step: C_STEP
         })
       .card_chart
@@ -38,8 +42,10 @@ mixin card(type)
         +field('H', 'h', {
           type: 'text',
           role: 'spinbutton',
+          pattern: '^[0-9+\/*\-\.]+$',
           'aria-valuemin': 0,
           'aria-valuemax': H_MAX,
+          inputmode: 'decimal',
           step: H_STEP
         })
       .card_chart
@@ -53,10 +59,12 @@ mixin card(type)
         +field('Alpha', 'a', {
           type: 'text',
           role: 'spinbutton',
-          value: ALPHA_MAX,
-          step: ALPHA_STEP,
           'aria-valuemin': 0,
           'aria-valuemax': ALPHA_MAX,
+          value: ALPHA_MAX,
+          step: ALPHA_STEP,
+          inputmode: 'decimal',
+          pattern: '[0-9]*(.[0-9]+)?'
         })
       +range('a', ALPHA_MAX, ALPHA_STEP, 100)
 

--- a/view/card/mixin.pug
+++ b/view/card/mixin.pug
@@ -7,9 +7,10 @@ mixin card(type)
       h2.card_title Lightness
       .card_number
         +field('L', 'l', {
-          type: 'number',
-          min: 0,
-          max: 100,
+          type: 'text',
+          role: 'spinbutton',
+          'aria-valuemin': 0,
+          'aria-valuemax': 100,
           step: L_STEP
         })
       .card_chart
@@ -21,8 +22,9 @@ mixin card(type)
       h2.card_title Chroma
       .card_number
         +field('C', 'c', {
-          type: 'number',
-          min: 0,
+          type: 'text',
+          role: 'spinbutton',
+          'aria-valuemin': 0,
           step: C_STEP
         })
       .card_chart
@@ -34,9 +36,10 @@ mixin card(type)
       h2.card_title Hue
       .card_number
         +field('H', 'h', {
-          type: 'number',
-          min: 0,
-          max: H_MAX,
+          type: 'text',
+          role: 'spinbutton',
+          'aria-valuemin': 0,
+          'aria-valuemax': H_MAX,
           step: H_STEP
         })
       .card_chart
@@ -48,11 +51,12 @@ mixin card(type)
       h2.card_title Alpha
       .card_number
         +field('Alpha', 'a', {
-          type: 'number',
-          min: 0,
+          type: 'text',
+          role: 'spinbutton',
           value: ALPHA_MAX,
-          max: ALPHA_MAX,
           step: ALPHA_STEP,
+          'aria-valuemin': 0,
+          'aria-valuemax': ALPHA_MAX,
         })
       +range('a', ALPHA_MAX, ALPHA_STEP, 100)
 

--- a/view/code/index.ts
+++ b/view/code/index.ts
@@ -24,7 +24,7 @@ let noteFallback = document.querySelector<HTMLDivElement>(
 
 let format = document.querySelector<HTMLSelectElement>('.code select')!
 
-function toggle(input: HTMLInputElement, invalid: boolean): void {
+export function toggle(input: HTMLInputElement, invalid: boolean): void {
   if (invalid) {
     input.setAttribute('aria-invalid', 'true')
   } else {

--- a/view/field/index.css
+++ b/view/field/index.css
@@ -16,7 +16,8 @@
   border: none;
   border-radius: var(--radius);
 
-  &[type="number"] {
+  &[role="spinbutton"] {
+    padding-inline-end: 23px;
     text-align: right;
   }
 
@@ -32,6 +33,32 @@
   .field.is-options & {
     border-top-right-radius: 0;
     border-bottom-right-radius: 0;
+  }
+}
+
+.field_controls {
+  position: absolute;
+  inset-inline-end: 7px;
+  top: 50%;
+  display: inline-flex;
+  flex-direction: column;
+  gap: 1px;
+  overflow: hidden;
+  border-radius: 23px;
+  transform: translateY(-50%);
+}
+
+.field_control {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 12px;
+  height: 9px;
+  background: var(--surface-1);
+  border: none;
+
+  & svg {
+    pointer-events: none;
   }
 }
 
@@ -108,4 +135,8 @@
 .field_button > svg {
   width: 16px;
   height: 16px;
+}
+
+.field_control:first-child > svg {
+  transform: rotate(180deg);
 }

--- a/view/field/index.ts
+++ b/view/field/index.ts
@@ -1,3 +1,5 @@
+import { toggle } from '../code/index.js'
+
 let fields = document.querySelectorAll<HTMLDivElement>('.field')
 let meta = document.querySelector<HTMLMetaElement>('meta[name=viewport]')!
 
@@ -59,9 +61,8 @@ for (let field of fields) {
   let input = field.querySelector<HTMLInputElement>('input')!
   input.addEventListener('focus', onFocus)
 
-  if (input.type === 'number') {
-    input.addEventListener('keydown', onKeyDown)
-    input.addEventListener('input', onInput)
+  if (input.getAttribute('role') === 'spinbutton') {
+    useSpinButton(input)
   }
 
   let hotkey = `Key${field
@@ -83,3 +84,135 @@ window.addEventListener('keyup', e => {
     e.target.blur()
   }
 })
+
+function removeByPosition(str: string, position: number): string {
+  return str.slice(0, position) + str.slice(position + 1)
+}
+
+export interface SpinEvent extends Event {
+  detail: {
+    action: 'increase' | 'decrease' | 'setMinimum' | 'setMaximum'
+  }
+}
+
+let draggableRect: DOMRect | null = null
+let currentNotifyCb = (): void => {}
+let pinchTimer: number
+
+function useSpinButton(input: HTMLInputElement): void {
+  let container = input.nextElementSibling!
+  let increase = container.querySelector<HTMLButtonElement>('.is-increase')!
+  let decrease = container.querySelector<HTMLButtonElement>('.is-decrease')!
+
+  function changeNotice(type: SpinEvent['detail']['action']): void {
+    if (/[0-9]/.test(input.value.charAt(input.value.length - 1))) {
+      let event = new CustomEvent('spin', { detail: { action: type } })
+
+      toggle(input, false)
+      input.dispatchEvent(event)
+    } else {
+      toggle(input, true)
+    }
+  }
+
+  function onPressed(e: MouseEvent): void {
+    if (e.button !== 0) return
+    e.preventDefault()
+
+    let target = e.target as HTMLButtonElement
+    let increased = target === increase
+
+    window.addEventListener('mousemove', onDragging)
+    window.addEventListener('mouseup', onDispose)
+
+    currentNotifyCb = () => {
+      if (increased) {
+        changeNotice('increase')
+      } else {
+        changeNotice('decrease')
+      }
+    }
+
+    draggableRect = target.getBoundingClientRect()
+    onPinchButton(400)
+  }
+
+  function onDragging(e: MouseEvent): void {
+    let target = e.target as HTMLButtonElement
+    if (!draggableRect) return
+
+    let increased = target === increase
+    let boundary = increased ? draggableRect.bottom : draggableRect.top
+
+    if (boundary > e.clientY) {
+      currentNotifyCb = () => {
+        changeNotice('increase')
+      }
+    } else {
+      currentNotifyCb = () => {
+        changeNotice('decrease')
+      }
+    }
+  }
+
+  function onPinchButton(delay: number): void {
+    clearTimeout(pinchTimer)
+    currentNotifyCb()
+    pinchTimer = setTimeout(() => {
+      onPinchButton(30)
+    }, delay)
+  }
+
+  function onKeyPressed(e: KeyboardEvent): void {
+    onKeyDown(e)
+
+    switch (e.key) {
+      case 'ArrowUp':
+        e.preventDefault()
+        changeNotice('increase')
+        break
+      case 'ArrowDown':
+        e.preventDefault()
+        changeNotice('decrease')
+        break
+      case 'Home':
+        e.preventDefault()
+        changeNotice('setMinimum')
+        break
+      case 'End':
+        e.preventDefault()
+        changeNotice('setMaximum')
+        break
+    }
+  }
+
+  function onDispose(): void {
+    clearTimeout(pinchTimer)
+    window.removeEventListener('mouseup', onDispose)
+    window.removeEventListener('mousemove', onDragging)
+  }
+
+  function onFieldInput(e: Event): void {
+    onInput(e)
+
+    if (e instanceof InputEvent) {
+      let value = input.value
+      let caretPosition = input.selectionStart!
+
+      if (!input.checkValidity()) {
+        input.value = removeByPosition(value, caretPosition - 1)
+        toggle(input, true)
+      } else {
+        toggle(input, false)
+      }
+    }
+
+    input.setAttribute('aria-valuenow', input.value)
+  }
+
+  increase.addEventListener('mousedown', onPressed)
+  decrease.addEventListener('mousedown', onPressed)
+
+  input.addEventListener('keydown', onKeyPressed)
+  input.addEventListener('input', onFieldInput)
+}

--- a/view/field/mixin.pug
+++ b/view/field/mixin.pug
@@ -2,6 +2,12 @@ mixin field(label, hotkey, opts = {})
   .field( class=opts.options ? 'is-options' : '' )
     kbd.field_hotkey= hotkey
     input.field_input( aria-label=label )&attributes({ type: 'text', ...opts })
+    if (opts.role === 'spinbutton')
+      .field_controls( aria-hidden="true" )
+        button.field_control.is-increase( tabindex="-1" )
+          include ./down.svg
+        button.field_control.is-decrease( tabindex="-1" )
+          include ./down.svg
     if opts.options
       .field_options
         select.field_select( aria-label=opts.optionsLabel )


### PR DESCRIPTION
## Description (WIP)

Example of implementation #74

## Checklist

- [ ] - Show `spinbutton` on desktop only (?)
- [ ] - Test this component on a screen reader ([w3.org](https://www.w3.org/WAI/ARIA/apg/patterns/spinbutton/))
- [ ] - Button highlighting by pressing and holding with the mouse and moving by Y
- [x] - Add `inputmode` for input
- [x] - Support keyboard `ArrowUp`, `ArrowDown`, `Home`, `End`
- [X] - Support for holding the button and `increasing` or `decreasing` the value
- [x] - Support for increasing or decreasing the value when holding down and changing the position of the cursor by Y
- [x] - Validating the value, allowing only numbers, `.` and operators `+, -, /, *` (only numbers are allowed in the `alpha` field).

I would welcome suggestions on what can be fixed or explained