### PR TITLE
Avoid hard coded interpreter path

### DIFF
--- a/lch.sh
+++ b/lch.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 
 rm dist/favicon.ico
 mv dist/favicon-lch.ico dist/favicon.ico


### PR DESCRIPTION
The test suite currently fails for me with:

```console
$ pnpm test
…
│ sh: line 1: ./lch.sh: cannot execute: required file not found
│  ELIFECYCLE  Command failed.
```

The test hard codes the path `/usr/bin/bash`, but this is not the location of Bash on my system. For improved portability, I suggest [using `/usr/bin/env`](https://en.wikipedia.org/wiki/Shebang_(Unix)#Program_location) to detect `bash` in the current environment.