### PR TITLE
Detect hotkeys by value, not physical position

### DIFF
--- a/view/field/index.ts
+++ b/view/field/index.ts
@@ -63,9 +63,9 @@ function isSpecial(e: KeyboardEvent): boolean {
 }
 
 function onKeyDown(e: KeyboardEvent): void {
-  if (hotkeys[e.code] && !isSpecial(e)) {
+  if (hotkeys[e.key] && !isSpecial(e)) {
     e.preventDefault()
-    hotkeys[e.code]?.focus()
+    hotkeys[e.key]?.focus()
   }
 }
 
@@ -79,10 +79,7 @@ for (let field of fields) {
     useSpinButton(input)
   }
 
-  let hotkey = `Key${field
-    .querySelector('kbd')!
-    .innerText.trim()
-    .toUpperCase()}`
+  let hotkey = field.querySelector('kbd')!.innerText.trim().toLowerCase()
   hotkeys[hotkey] = input
 }
 
@@ -93,8 +90,8 @@ function isInput(el: EventTarget | null): el is HTMLInputElement {
 window.addEventListener('keyup', e => {
   if (isSpecial(e)) return
   if (e.target === document.body) {
-    hotkeys[e.code]?.focus()
-  } else if (isInput(e.target) && e.code === 'Escape') {
+    hotkeys[e.key]?.focus()
+  } else if (isInput(e.target) && e.key === 'Escape') {
     e.target.blur()
   }
 })


### PR DESCRIPTION
I’m unable to type numbers that contain the digits `6` or `9`. When I press the <kbd>6</kbd> key, no text is entered and instead the Lightness field is focused:

[screencast](https://github.com/evilmartians/oklch-picker/assets/1844746/4ee920b0-ee00-4417-9578-252d231d0a80)

Similarly, when I press the <kbd>9</kbd> key no text is entered and instead the OKLCH CSS field is focused.

Upon investigation I can see that the page is attempting to identify keys by their *physical position* rather than their actual meaning. As [warned on MDN](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent#instance_properties), the `code` property encodes the physical position of a key by naming what key would hypothetically be at that position on a QWERTY layout. For users with non-QWERTY layouts, this name does not necessarily correspond with the actual behavior of the key.

Fortunately the solution is trivial; read the property that encodes actual meaning instead of physical position.