### PR TITLE
Fix aria-hidden attribute in pug template

### DIFF
--- a/view/field/mixin.pug
+++ b/view/field/mixin.pug
@@ -1,6 +1,6 @@
 mixin field(label, hotkey, opts = {})
   .field( class=opts.options ? 'is-options' : '' )
-    kbd.field_hotkey( aria-hidden )= hotkey
+    kbd.field_hotkey( aria-hidden="true" )= hotkey
     input.field_input( aria-label=label aria-keyshortcuts=hotkey )&attributes({ type: 'text', ...opts })
     if (opts.role === 'spinbutton')
       button.field_control.is-increase( tabindex="-1" aria-hidden="true" )


### PR DESCRIPTION
Seems like when no value is provided for `aria-hidden` attribute pug just uses attribute name as a value. Code before that small change resulted in following HTML:

```html
<kbd class="field_hotkey" aria-hidden="aria-hidden">l</kbd>
```

Now attribute will be correct:

```html
<kbd class="field_hotkey" aria-hidden="true">l</kbd>
```
