### PR TITLE
Add Undo/Redo

### DIFF
--- a/lib/hotkeys.ts
+++ b/lib/hotkeys.ts
@@ -1,27 +1,27 @@
-const MODIFIERS = {
-  alt: 'altKey',
-  ctrl: 'ctrlKey',
-  meta: 'metaKey',
-  shift: 'shiftKey'
-} as const
-
-type Modifier = keyof typeof MODIFIERS
+const NON_ENGLISH_LAYOUT = /^[^\x00-\x7F]$/
 
 function compareHotkey(hotkey: string, e: KeyboardEvent): boolean {
-  let keys = hotkey.split('+')
+  let prefix = ''
+  if (e.metaKey) prefix += 'meta+'
+  if (e.ctrlKey) prefix += 'ctrl+'
+  if (e.altKey) prefix += 'alt+'
+  if (e.shiftKey) prefix += 'shift+'
 
-  for (let key of keys) {
-    if (key in MODIFIERS) {
-      let modifier = MODIFIERS[key as Modifier]
-      if (!e[modifier]) {
-        return false
-      }
-    } else if (e.key.toLowerCase() !== key.toLowerCase()) {
-      return false
-    }
+  let code = prefix
+  if (e.key === '+') {
+    code += 'plus'
+  } else {
+    code += e.key.toLowerCase()
   }
 
-  return true
+  let isMatch = code === hotkey
+
+  if (!isMatch && NON_ENGLISH_LAYOUT.test(e.key) && /^Key.$/.test(e.code)) {
+    let enKey = e.code.replace(/^Key/, '').toLowerCase()
+    isMatch = prefix + enKey === hotkey
+  }
+
+  return isMatch
 }
 
 export function isHotkey(hotkeys: string[], e: KeyboardEvent): boolean {

--- a/lib/hotkeys.ts
+++ b/lib/hotkeys.ts
@@ -1,5 +1,12 @@
 const NON_ENGLISH_LAYOUT = /^[^\x00-\x7F]$/
 
+export function convertKey(e: KeyboardEvent): string {
+  if (NON_ENGLISH_LAYOUT.test(e.key) && /^Key.$/.test(e.code)) {
+    return e.code.replace(/^Key/, '').toLowerCase()
+  }
+  return e.key.toLowerCase()
+}
+
 function compareHotkey(hotkey: string, e: KeyboardEvent): boolean {
   let prefix = ''
   if (e.metaKey) prefix += 'meta+'
@@ -7,21 +14,9 @@ function compareHotkey(hotkey: string, e: KeyboardEvent): boolean {
   if (e.altKey) prefix += 'alt+'
   if (e.shiftKey) prefix += 'shift+'
 
-  let code = prefix
-  if (e.key === '+') {
-    code += 'plus'
-  } else {
-    code += e.key.toLowerCase()
-  }
+  let code = prefix + convertKey(e)
 
-  let isMatch = code === hotkey
-
-  if (!isMatch && NON_ENGLISH_LAYOUT.test(e.key) && /^Key.$/.test(e.code)) {
-    let enKey = e.code.replace(/^Key/, '').toLowerCase()
-    isMatch = prefix + enKey === hotkey
-  }
-
-  return isMatch
+  return code === hotkey
 }
 
 export function isHotkey(hotkeys: string[], e: KeyboardEvent): boolean {

--- a/lib/hotkeys.ts
+++ b/lib/hotkeys.ts
@@ -1,0 +1,29 @@
+const MODIFIERS = {
+  alt: 'altKey',
+  control: 'ctrlKey',
+  meta: 'metaKey',
+  shift: 'shiftKey'
+} as const
+
+type Modifier = keyof typeof MODIFIERS
+
+function compareHotkey(hotkey: string, e: KeyboardEvent): boolean {
+  let keys = hotkey.split('+')
+
+  for (let key of keys) {
+    if (key in MODIFIERS) {
+      let modifier = MODIFIERS[key as Modifier]
+      if (!e[modifier]) {
+        return false
+      }
+    } else if (e.key.toLowerCase() !== key.toLowerCase()) {
+      return false
+    }
+  }
+
+  return true
+}
+
+export function isHotkey(hotkeys: string[], e: KeyboardEvent): boolean {
+  return hotkeys.some(k => compareHotkey(k, e))
+}

--- a/lib/hotkeys.ts
+++ b/lib/hotkeys.ts
@@ -1,6 +1,6 @@
 const MODIFIERS = {
   alt: 'altKey',
-  control: 'ctrlKey',
+  ctrl: 'ctrlKey',
   meta: 'metaKey',
   shift: 'shiftKey'
 } as const

--- a/stores/history.ts
+++ b/stores/history.ts
@@ -3,8 +3,8 @@ import { atom } from 'nanostores'
 import { debounce } from '../lib/time.js'
 import { current, type LchValue } from './current.js'
 
-let $undos = atom<LchValue[]>([])
-let $redos = atom<LchValue[]>([])
+let undos = atom<LchValue[]>([])
+let redos = atom<LchValue[]>([])
 let fromUndoRedo = false
 
 current.subscribe(
@@ -14,35 +14,35 @@ current.subscribe(
       return
     }
 
-    $undos.set([...$undos.get(), curr])
-    $redos.set([])
+    undos.set([...undos.get(), curr])
+    redos.set([])
   })
 )
 
 export function undo(): void {
-  let stack = $undos.get()
+  let stack = undos.get()
   if (stack.length < 2) {
     return
   }
 
   let prev = stack[stack.length - 2]
   let curr = stack[stack.length - 1]
-  $redos.set([...$redos.get(), curr])
-  $undos.set(stack.slice(0, -1))
+  redos.set([...redos.get(), curr])
+  undos.set(stack.slice(0, -1))
 
   fromUndoRedo = true
   current.set(prev)
 }
 
 export function redo(): void {
-  let stack = $redos.get()
+  let stack = redos.get()
   if (stack.length < 1) {
     return
   }
 
   let next = stack[stack.length - 1]
-  $undos.set([...$undos.get(), next])
-  $redos.set(stack.slice(0, -1))
+  undos.set([...undos.get(), next])
+  redos.set(stack.slice(0, -1))
 
   fromUndoRedo = true
   current.set(next)

--- a/stores/history.ts
+++ b/stores/history.ts
@@ -1,0 +1,56 @@
+import { atom } from 'nanostores'
+
+import { debounce } from '../lib/time.js'
+import { current, type LchValue } from './current.js'
+
+let $undos = atom<LchValue[]>([])
+let $redos = atom<LchValue[]>([])
+let $prev = atom<LchValue>({ a: 100, c: 0, h: 0, l: 0 })
+let fromUndoRedo = false
+
+current.subscribe(
+  debounce(100, (curr, oldValue) => {
+    if (!oldValue) {
+      $prev.set(curr)
+      return
+    }
+    if (fromUndoRedo) {
+      fromUndoRedo = false
+      return
+    }
+
+    $undos.set([...$undos.get(), $prev.get()])
+    $redos.set([])
+    $prev.set(curr)
+  })
+)
+
+export function undo(): void {
+  let stack = $undos.get()
+  if (stack.length === 0) {
+    return
+  }
+
+  let last = stack[stack.length - 1]
+  $redos.set([...$redos.get(), $prev.get()])
+  $undos.set(stack.slice(0, -1))
+
+  fromUndoRedo = true
+  $prev.set(last)
+  current.set(last)
+}
+
+export function redo(): void {
+  let stack = $redos.get()
+  if (stack.length === 0) {
+    return
+  }
+
+  let last = stack[stack.length - 1]
+  $undos.set([...$undos.get(), $prev.get()])
+  $redos.set(stack.slice(0, -1))
+
+  fromUndoRedo = true
+  $prev.set(last)
+  current.set(last)
+}

--- a/view/base/index.ts
+++ b/view/base/index.ts
@@ -4,11 +4,8 @@ import { redo, undo } from '../../stores/history.js'
 import { loading } from '../../stores/loading.js'
 
 const IS_MAC = /Mac|iPod|iPhone|iPad/.test(window.navigator.platform)
-
-const HOTKEYS = {
-  redo: IS_MAC ? ['meta+shift+z'] : ['ctrl+shift+z', 'ctrl+y'],
-  undo: IS_MAC ? ['meta+z'] : ['ctrl+z']
-}
+const redoHotkeys = IS_MAC ? ['meta+shift+z'] : ['ctrl+shift+z', 'ctrl+y']
+const undoHotkeys = IS_MAC ? ['meta+z'] : ['ctrl+z']
 
 accent.subscribe(({ main, surface }) => {
   document.body.style.setProperty('--accent', main)
@@ -28,10 +25,10 @@ document.body.addEventListener('mouseup', () => {
 })
 
 document.body.addEventListener('keydown', e => {
-  if (isHotkey(HOTKEYS.redo, e)) {
+  if (isHotkey(redoHotkeys, e)) {
     e.preventDefault()
     redo()
-  } else if (isHotkey(HOTKEYS.undo, e)) {
+  } else if (isHotkey(undoHotkeys, e)) {
     e.preventDefault()
     undo()
   }

--- a/view/base/index.ts
+++ b/view/base/index.ts
@@ -1,4 +1,5 @@
 import { accent } from '../../stores/accent.js'
+import { redo, undo } from '../../stores/history.js'
 import { loading } from '../../stores/loading.js'
 
 accent.subscribe(({ main, surface }) => {
@@ -16,4 +17,17 @@ document.body.addEventListener('mousedown', () => {
 
 document.body.addEventListener('mouseup', () => {
   document.body.classList.remove('is-grabbing')
+})
+
+document.body.addEventListener('keydown', e => {
+  if (
+    ((e.ctrlKey || e.metaKey) && e.shiftKey && e.key.toLowerCase() === 'z') ||
+    ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'y')
+  ) {
+    e.preventDefault()
+    redo()
+  } else if (e.key === 'z' && (e.ctrlKey || e.metaKey)) {
+    e.preventDefault()
+    undo()
+  }
 })

--- a/view/base/index.ts
+++ b/view/base/index.ts
@@ -26,7 +26,7 @@ document.body.addEventListener('keydown', e => {
   ) {
     e.preventDefault()
     redo()
-  } else if (e.key === 'z' && (e.ctrlKey || e.metaKey)) {
+  } else if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'z') {
     e.preventDefault()
     undo()
   }

--- a/view/base/index.ts
+++ b/view/base/index.ts
@@ -4,8 +4,8 @@ import { redo, undo } from '../../stores/history.js'
 import { loading } from '../../stores/loading.js'
 
 const IS_MAC = /Mac|iPod|iPhone|iPad/.test(window.navigator.platform)
-const redoHotkeys = IS_MAC ? ['meta+shift+z'] : ['ctrl+shift+z', 'ctrl+y']
-const undoHotkeys = IS_MAC ? ['meta+z'] : ['ctrl+z']
+const REDO_HOTKEYS = IS_MAC ? ['meta+shift+z'] : ['ctrl+shift+z', 'ctrl+y']
+const UNDO_HOTKEYS = IS_MAC ? ['meta+z'] : ['ctrl+z']
 
 accent.subscribe(({ main, surface }) => {
   document.body.style.setProperty('--accent', main)
@@ -25,10 +25,10 @@ document.body.addEventListener('mouseup', () => {
 })
 
 document.body.addEventListener('keydown', e => {
-  if (isHotkey(redoHotkeys, e)) {
+  if (isHotkey(REDO_HOTKEYS, e)) {
     e.preventDefault()
     redo()
-  } else if (isHotkey(undoHotkeys, e)) {
+  } else if (isHotkey(UNDO_HOTKEYS, e)) {
     e.preventDefault()
     undo()
   }

--- a/view/base/index.ts
+++ b/view/base/index.ts
@@ -1,6 +1,14 @@
+import { isHotkey } from '../../lib/hotkeys.js'
 import { accent } from '../../stores/accent.js'
 import { redo, undo } from '../../stores/history.js'
 import { loading } from '../../stores/loading.js'
+
+const IS_MAC = /Mac|iPod|iPhone|iPad/.test(window.navigator.platform)
+
+const HOTKEYS = {
+  redo: IS_MAC ? ['meta+shift+z'] : ['ctrl+shift+z', 'ctrl+y'],
+  undo: IS_MAC ? ['meta+z'] : ['ctrl+z']
+}
 
 accent.subscribe(({ main, surface }) => {
   document.body.style.setProperty('--accent', main)
@@ -20,13 +28,10 @@ document.body.addEventListener('mouseup', () => {
 })
 
 document.body.addEventListener('keydown', e => {
-  if (
-    ((e.ctrlKey || e.metaKey) && e.shiftKey && e.key.toLowerCase() === 'z') ||
-    ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'y')
-  ) {
+  if (isHotkey(HOTKEYS.redo, e)) {
     e.preventDefault()
     redo()
-  } else if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'z') {
+  } else if (isHotkey(HOTKEYS.undo, e)) {
     e.preventDefault()
     undo()
   }

--- a/view/field/index.ts
+++ b/view/field/index.ts
@@ -1,7 +1,7 @@
+import { convertKey } from '../../lib/hotkeys.js'
+
 let fields = document.querySelectorAll<HTMLDivElement>('.field')
 let meta = document.querySelector<HTMLMetaElement>('meta[name=viewport]')!
-
-const NON_ENGLISH_LAYOUT = /^[^\x00-\x7F]$/
 
 export function setValid(input: HTMLInputElement): void {
   input.removeAttribute('aria-invalid')
@@ -83,13 +83,9 @@ function isInput(el: EventTarget | null): el is HTMLInputElement {
 }
 
 function findNextFocus(e: KeyboardEvent): HTMLElement | undefined {
-  let next: HTMLElement | undefined
-  next = hotkeys[e.key.toLowerCase()]
-  if (!next && NON_ENGLISH_LAYOUT.test(e.key) && /^Key.$/.test(e.code)) {
-    let enKey = e.code.replace(/^Key/, '').toLowerCase()
-    next = hotkeys[enKey]
-  }
-  return next
+  let key = convertKey(e)
+
+  return hotkeys[key]
 }
 
 window.addEventListener('keyup', e => {


### PR DESCRIPTION
Resolves #148 

- fromUndoRedo is needed to prevent pushing prev color to undo, after we updated current in undo/redo.
- undos stores current as last item, so it never should be empty.
- ~$prev is needed for storing previous color. I tried to use oldValue from subscribe, but because of debounce, it can be the same as value.~
- ~$prev initialised with 0 color to avoid checking for null. I set correct first value in subscribe, when oldValue is not passed~
- ~on cmd + Y in macOS Safari usually opens history, is it okay that now I prevent to open it?~