### PR TITLE
Use toGamut instead of clampChroma

### DIFF
--- a/lib/colors.ts
+++ b/lib/colors.ts
@@ -127,9 +127,7 @@ export function forceP3(color: Color): P3 {
   return { ...rgb(color), mode: 'p3' }
 }
 
-export function toRgb(color: Color): Rgb {
-  return toGamut('rgb', COLOR_FN)(color)
-}
+export let toRgb = toGamut('rgb', COLOR_FN)
 
 export function formatRgb(color: Rgb): string {
   let r = Math.round(25500 * color.r) / 100

--- a/lib/colors.ts
+++ b/lib/colors.ts
@@ -1,5 +1,4 @@
 import {
-  clampChroma,
   type Color,
   formatCss,
   formatRgb as formatRgbFast,
@@ -20,6 +19,7 @@ import {
   type P3,
   type Rec2020,
   type Rgb,
+  toGamut,
   useMode
 } from 'culori/fn'
 
@@ -128,7 +128,7 @@ export function forceP3(color: Color): P3 {
 }
 
 export function toRgb(color: Color): Rgb {
-  return rgb(clampChroma(color, COLOR_FN))
+  return toGamut('rgb', COLOR_FN)(color)
 }
 
 export function formatRgb(color: Rgb): string {

--- a/stores/current.ts
+++ b/stores/current.ts
@@ -1,5 +1,5 @@
 import type { Color } from 'culori/fn'
-import { clampChroma } from 'culori/fn'
+import { toGamut } from 'culori/fn'
 import { map } from 'nanostores'
 
 import {
@@ -189,7 +189,8 @@ export function setCurrentFromColor(origin: Color): void {
     let originSpace = getSpace(origin)
     let accurate = LCH ? lch(origin) : oklch(origin)
     if (originSpace === Space.sRGB && getSpace(accurate) !== Space.sRGB) {
-      accurate = clampChroma(accurate, COLOR_FN) as AnyLch
+      let rgbAccurate = toGamut('rgb', COLOR_FN)(accurate)
+      accurate = LCH ? lch(rgbAccurate) : oklch(rgbAccurate)
     }
     let rounded = roundValue(colorToValue(accurate), COLOR_FN)
     if (getSpace(valueToColor(rounded)) === originSpace) {

--- a/stores/current.ts
+++ b/stores/current.ts
@@ -1,5 +1,4 @@
 import type { Color } from 'culori/fn'
-import { toGamut } from 'culori/fn'
 import { map } from 'nanostores'
 
 import {
@@ -8,7 +7,8 @@ import {
   getSpace,
   lch,
   oklch,
-  Space
+  Space,
+  toRgb
 } from '../lib/colors.js'
 import { debounce } from '../lib/time.js'
 import { reportFreeze, startPainting } from './benchmark.js'
@@ -189,7 +189,7 @@ export function setCurrentFromColor(origin: Color): void {
     let originSpace = getSpace(origin)
     let accurate = LCH ? lch(origin) : oklch(origin)
     if (originSpace === Space.sRGB && getSpace(accurate) !== Space.sRGB) {
-      let rgbAccurate = toGamut('rgb', COLOR_FN)(accurate)
+      let rgbAccurate = toRgb(accurate)
       accurate = LCH ? lch(rgbAccurate) : oklch(rgbAccurate)
     }
     let rounded = roundValue(colorToValue(accurate), COLOR_FN)


### PR DESCRIPTION
Using `clampChroma` is a too rough way for mapping p3 to sRGB. This can result in unnecessarily desaturated fallbacks.

You can use `toGamut` as a way of mapping closer to the CSS specification (https://drafts.csswg.org/css-color/#css-gamut-mapping).

`clampChroma`:
<img width="341" alt="image" src="https://github.com/user-attachments/assets/e82d1294-bf96-4ddb-81f9-e068c44c35cf">
<img width="341" alt="image" src="https://github.com/user-attachments/assets/0387f7f4-ec59-4401-ad87-824c78050f82">

`toGamut`:
<img width="341" alt="image" src="https://github.com/user-attachments/assets/ff775eba-34fe-4d05-9697-b556e6dddf99">
<img width="341" alt="image" src="https://github.com/user-attachments/assets/86c33df2-224b-4d34-97fb-1076cae7d7e7">

P.S.: I'm not sure which case is being handled in the changed lines of `/stores/current.ts`, so if you're gonna merge this please check it carefully.