### PR TITLE
fix checkbox :checked styles

### DIFF
--- a/view/checkbox/index.css
+++ b/view/checkbox/index.css
@@ -43,9 +43,9 @@
   opacity: 0%;
   transition: opacity 150ms;
 
-  .checkbox_input:checked + .checkbox_control > & {
+  /* .checkbox_input:checked + .checkbox_control > & {
     opacity: 100%;
-  }
+  } */
 }
 
 .checkbox_input:checked + .checkbox_control > .checkbox_icon::before {
@@ -64,9 +64,9 @@
   transition: transform 150ms;
   transform: translateX(0);
 
-  .checkbox_input:checked + .checkbox_control > & {
+  /* .checkbox_input:checked + .checkbox_control > & {
     transform: translateX(24px);
-  }
+  } */
 }
 
 .checkbox_input:checked + .checkbox_control > .checkbox_icon::after {

--- a/view/checkbox/index.css
+++ b/view/checkbox/index.css
@@ -48,6 +48,10 @@
   }
 }
 
+.checkbox_input:checked + .checkbox_control > .checkbox_icon::before {
+  opacity: 100%;
+}
+
 .checkbox_icon::after {
   position: absolute;
   top: 2px;
@@ -63,4 +67,8 @@
   .checkbox_input:checked + .checkbox_control > & {
     transform: translateX(24px);
   }
+}
+
+.checkbox_input:checked + .checkbox_control > .checkbox_icon::after {
+  transform: translateX(24px);
 }


### PR DESCRIPTION
Временное решение до выяснения обстоятельств, просто чтобы работало. Конкретно в этих строчках не работал селектор `&`, в соседних, тех, что с `:focus`, работает без проблем. Понятия не имею, в чём дело, последнее изменение в `.postcssrc` было в 2022 году.