### PR TITLE
ARIA hide down SVG icon and <canvas> elements

### DIFF
--- a/view/field/mixin.pug
+++ b/view/field/mixin.pug
@@ -10,5 +10,5 @@ mixin field(label, hotkey, opts = {})
         select.field_select( aria-label=opts.optionsLabel )
           for value, key in opts.options
             option( value=key )= value
-        .field_button
+        .field_button( aria-hidden="true" )
           include ./down.svg

--- a/view/range/mixin.pug
+++ b/view/range/mixin.pug
@@ -1,5 +1,5 @@
 mixin range(type, max, step, defaultValue)
-  .range( class=`is-${type}` )
+  .range( class=`is-${type}` aria-hidden="true" )
     if type !== 'a'
       canvas.range_space
     input.range_input(
@@ -7,7 +7,6 @@ mixin range(type, max, step, defaultValue)
       min="0"
       max=max
       step=step / 100
-      aria-hidden="true"
       value=defaultValue
       tabindex="-1"
       list=`range_${type}_values`


### PR DESCRIPTION
Closes #202 

## Considerations

- Given how the `<select>` and its respective trigger `<button>` are implemented (and their pairing with the `<input>` element), I opted to put `aria-hidden` on the entire button (this ensures that a "group" isn't read out, even with `aria-hidden` on the SVG icon, when using VoiceOver and Chrome). I treated this button as purely visual, since the entire screen reader experience is handled by the select itself. Thoughts?
- Tested with VoiceOver + Chrome and VoiceOver + Safari.