### PR TITLE
Fix worker message listener leak causing partial canvas renders

### DIFF
--- a/lib/workers.ts
+++ b/lib/workers.ts
@@ -75,7 +75,7 @@ export function prepareWorkers<
           startPending(lastPending.get(type) ?? anyValue(lastPending))
           onFinal()
         }
-      })
+      }, { once: true })
       worker.postMessage(messages[i])
     }
   }


### PR DESCRIPTION
Each call to `startWork` adds a new `message` listener to every worker, but never removes it. When a worker is reused on the next render, it has accumulated listeners from all previous renders each one fires on the new message, incrementing `finished` multiple times and triggering `onFinal()` prematurely with an incomplete `parts` array. As a results graph render is broken

<img width="836" height="666" alt="image" src="https://github.com/user-attachments/assets/8e707e2f-4e8b-4dde-a453-329525877d75" />
