### PR TITLE
Improve benchmark overlay with batch runner and p95 stats

### DIFF
--- a/lib/workers.ts
+++ b/lib/workers.ts
@@ -10,6 +10,16 @@ interface StartWork<TaskData extends object, ResultData extends object> {
 
 const TOTAL_WORKERS = navigator.hardwareConcurrency
 
+let pendingWorkers = 0
+let idleResolvers: (() => void)[] = []
+
+export function waitForWorkersIdle(): Promise<void> {
+  if (pendingWorkers === 0) return Promise.resolve()
+  return new Promise<void>(resolve => {
+    idleResolvers.push(resolve)
+  })
+}
+
 function anyValue<V>(map: Map<string, V>): undefined | V {
   return map.values().next().value
 }
@@ -70,12 +80,20 @@ export function prepareWorkers<
         available.push(worker)
 
         finished += 1
+        pendingWorkers -= 1
+        if (pendingWorkers === 0 && idleResolvers.length > 0) {
+          let toResolve = idleResolvers
+          idleResolvers = []
+          for (let resolve of toResolve) resolve()
+        }
+
         if (finished === started) {
           busy.delete(type)
           startPending(lastPending.get(type) ?? anyValue(lastPending))
           onFinal()
         }
       }, { once: true })
+      pendingWorkers += 1
       worker.postMessage(messages[i])
     }
   }

--- a/stores/benchmark.ts
+++ b/stores/benchmark.ts
@@ -69,18 +69,18 @@ export function reportFreeze(cb: () => void): void {
   lastBenchmark.set({ ...current })
 }
 
-export function clearHistory(): void {
+export function clearBenchmarkHistory(): void {
   history = []
   current = emptyFrame()
   hasPending = false
   lastBenchmark.set(emptyFrame())
 }
 
-export function getHistory(): readonly FrameRecord[] {
+export function getBenchmarkHistory(): readonly FrameRecord[] {
   return history
 }
 
-export function computeStats(values: number[]): {
+export function computeBenchmarkStats(values: number[]): {
   median: number
   p95: number
 } {

--- a/stores/benchmark.ts
+++ b/stores/benchmark.ts
@@ -3,52 +3,92 @@ import { map } from 'nanostores'
 
 import { benchmarking } from './url.ts'
 
-export let lastBenchmark = map({
-  freezeMax: 0,
-  freezeSum: 0,
-  paint: 0,
-  workerMax: 0,
-  workerSum: 0
-})
+export interface FrameRecord {
+  freezeMax: number
+  freezeSum: number
+  paint: number
+  workerMax: number
+  workerSum: number
+}
 
+function emptyFrame(): FrameRecord {
+  return {
+    freezeMax: 0,
+    freezeSum: 0,
+    paint: 0,
+    workerMax: 0,
+    workerSum: 0
+  }
+}
+
+export let lastBenchmark = map(emptyFrame())
+
+const HISTORY_MAX = 1000
+
+let history: FrameRecord[] = []
+let current: FrameRecord = emptyFrame()
 let paintStart = 0
+let hasPending = false
+
+export function flushCurrentFrame(): void {
+  if (!hasPending) return
+  history.push({ ...current })
+  if (history.length > HISTORY_MAX) history.shift()
+  current = emptyFrame()
+  hasPending = false
+}
 
 export function startPainting(): void {
-  if (benchmarking.get()) {
-    lastBenchmark.set({
-      freezeMax: 0,
-      freezeSum: 0,
-      paint: 0,
-      workerMax: 0,
-      workerSum: 0
-    })
-    paintStart = Date.now()
-  }
+  if (!benchmarking.get()) return
+  flushCurrentFrame()
+  paintStart = performance.now()
+  lastBenchmark.set(emptyFrame())
 }
 
 export function reportPaint(ms: number): void {
-  if (benchmarking.get()) {
-    lastBenchmark.setKey('paint', Date.now() - paintStart)
-    lastBenchmark.setKey('workerSum', lastBenchmark.get().workerSum + ms)
-    if (ms > lastBenchmark.get().workerMax) {
-      lastBenchmark.setKey('workerMax', ms)
-    }
-  }
+  if (!benchmarking.get()) return
+  hasPending = true
+  current.paint = performance.now() - paintStart
+  current.workerSum += ms
+  if (ms > current.workerMax) current.workerMax = ms
+  lastBenchmark.set({ ...current })
 }
 
 export function reportFreeze(cb: () => void): void {
-  if (benchmarking.get()) {
-    let start = Date.now()
+  if (!benchmarking.get()) {
     cb()
-    let ms = Date.now() - start
-
-    lastBenchmark.setKey('freezeSum', lastBenchmark.get().freezeSum + ms)
-    if (ms > lastBenchmark.get().freezeMax) {
-      lastBenchmark.setKey('freezeMax', ms)
-    }
-  } else {
-    cb()
+    return
   }
+  let start = performance.now()
+  cb()
+  let ms = performance.now() - start
+
+  hasPending = true
+  current.freezeSum += ms
+  if (ms > current.freezeMax) current.freezeMax = ms
+  lastBenchmark.set({ ...current })
+}
+
+export function clearHistory(): void {
+  history = []
+  current = emptyFrame()
+  hasPending = false
+  lastBenchmark.set(emptyFrame())
+}
+
+export function getHistory(): readonly FrameRecord[] {
+  return history
+}
+
+export function computeStats(values: number[]): {
+  median: number
+  p95: number
+} {
+  if (values.length === 0) return { median: 0, p95: 0 }
+  let sorted = values.toSorted((a, b) => a - b)
+  let mid = Math.floor(sorted.length * 0.5)
+  let p95Idx = Math.min(sorted.length - 1, Math.floor(sorted.length * 0.95))
+  return { median: sorted[mid], p95: sorted[p95Idx] }
 }
 
 const BEST_HUE = 150

--- a/view/benchmark/index.css
+++ b/view/benchmark/index.css
@@ -20,7 +20,54 @@
 
 .benchmark_value {
   display: inline-block;
-  min-width: 37px;
+  min-width: 52px;
   font-weight: 400;
+  font-variant-numeric: tabular-nums;
   text-align: right;
 }
+
+.benchmark_batch {
+  padding-top: 10px;
+  margin-top: 10px;
+  border-top: 1px solid oklch(1 0 0 / 30%);
+}
+
+.benchmark_run {
+  padding: 2px 8px;
+  font: inherit;
+  color: inherit;
+  background: oklch(1 0 0 / 15%);
+  border: 1px solid oklch(1 0 0 / 40%);
+}
+
+.benchmark_status {
+  margin-left: 8px;
+}
+
+.benchmark_table {
+  margin-top: 8px;
+  table-layout: fixed;
+  border-collapse: collapse;
+}
+
+.benchmark_table th,
+.benchmark_table td {
+  padding: 2px 0 2px 10px;
+  text-align: right;
+}
+
+.benchmark_table tbody th {
+  text-align: left;
+}
+
+.benchmark_table tbody td {
+  font-weight: 400;
+}
+
+.benchmark_table th:first-child,
+.benchmark_table td:first-child {
+  padding-left: 0;
+}
+
+.benchmark_table th:nth-child(1) { width: 110px; }
+.benchmark_table th:nth-child(n+2) { width: 56px; }

--- a/view/benchmark/index.pug
+++ b/view/benchmark/index.pug
@@ -23,8 +23,15 @@
           th
           th median
           th p95
+      -
+        const ROWS = [
+          { id: 'paint', label: 'Paint' },
+          { id: 'wmax', label: 'Worker max' },
+          { id: 'wsum', label: 'Worker sum' },
+          { id: 'fsum', label: 'Freeze sum' }
+        ]
       tbody
-        each row in [{ id: 'paint', label: 'Paint' }, { id: 'wmax', label: 'Worker max' }, { id: 'wsum', label: 'Worker sum' }, { id: 'fsum', label: 'Freeze sum' }]
+        each row in ROWS
           tr
             th= row.label
             td(class=`is-stat-${row.id}-median`) —

--- a/view/benchmark/index.pug
+++ b/view/benchmark/index.pug
@@ -1,16 +1,31 @@
 .benchmark( aria-live="polite" aria-label="Benchmark" aria-hidden="true" )
   .benchmark_row
-    = "Freeze max "
+    = "Freeze max "
     strong.benchmark_value.is-freeze-max
   .benchmark_row
-    = "Freeze sum "
+    = "Freeze sum "
     strong.benchmark_value.is-freeze-sum
   .benchmark_row
-    = "Worker max "
+    = "Worker max "
     strong.benchmark_value.is-worker-max
   .benchmark_row
-    = "Worker sum "
+    = "Worker sum "
     strong.benchmark_value.is-worker-sum
   .benchmark_row
-    = "Paint      "
+    = "Paint      "
     strong.benchmark_value.is-paint
+  .benchmark_batch
+    button.benchmark_run(type="button") Run 500
+    span.benchmark_status ready
+    table.benchmark_table
+      thead
+        tr
+          th
+          th median
+          th p95
+      tbody
+        each row in [{ id: 'paint', label: 'Paint' }, { id: 'wmax', label: 'Worker max' }, { id: 'wsum', label: 'Worker sum' }, { id: 'fsum', label: 'Freeze sum' }]
+          tr
+            th= row.label
+            td(class=`is-stat-${row.id}-median`) —
+            td(class=`is-stat-${row.id}-p95`) —

--- a/view/benchmark/index.ts
+++ b/view/benchmark/index.ts
@@ -1,10 +1,10 @@
 import { waitForWorkersIdle } from '../../lib/workers.ts'
 import {
-  clearHistory,
-  computeStats,
+  clearBenchmarkHistory,
+  computeBenchmarkStats,
   flushCurrentFrame,
   type FrameRecord,
-  getHistory,
+  getBenchmarkHistory,
   getLastBenchmarkColor,
   lastBenchmark
 } from '../../stores/benchmark.ts'
@@ -59,7 +59,7 @@ function renderStats(history: readonly FrameRecord[]): void {
     return
   }
   for (let c of statCells) {
-    let s = computeStats(history.map(r => r[c.key]))
+    let s = computeBenchmarkStats(history.map(r => r[c.key]))
     c.median.innerText = fmt(s.median)
     c.p95.innerText = fmt(s.p95)
   }
@@ -81,18 +81,18 @@ async function driveFrame(t: number): Promise<void> {
 
 async function runBatch(): Promise<void> {
   runBtn.disabled = true
-  clearHistory()
+  clearBenchmarkHistory()
   resetStats()
 
   for (let i = 0; i < BATCH_N; i++) {
     status.innerText = `${i + 1} / ${BATCH_N}`
     await driveFrame((i + 1) / BATCH_N)
-    if (i + 1 === WARMUP_N) clearHistory()
+    if (i + 1 === WARMUP_N) clearBenchmarkHistory()
   }
 
   flushCurrentFrame()
-  renderStats(getHistory())
-  status.innerText = `done (${getHistory().length})`
+  renderStats(getBenchmarkHistory())
+  status.innerText = `done (${getBenchmarkHistory().length})`
   runBtn.disabled = false
 }
 

--- a/view/benchmark/index.ts
+++ b/view/benchmark/index.ts
@@ -1,10 +1,20 @@
-import { getLastBenchmarkColor, lastBenchmark } from '../../stores/benchmark.ts'
+import { waitForWorkersIdle } from '../../lib/workers.ts'
+import {
+  clearHistory,
+  computeStats,
+  flushCurrentFrame,
+  type FrameRecord,
+  getHistory,
+  getLastBenchmarkColor,
+  lastBenchmark
+} from '../../stores/benchmark.ts'
+import { setCurrentComponents } from '../../stores/current.ts'
 import { benchmarking } from '../../stores/url.ts'
 
 let block = document.querySelector<HTMLDivElement>('.benchmark')!
 
-function getValue(id: string): HTMLSpanElement {
-  return block.querySelector<HTMLSpanElement>(`.benchmark_value.is-${id}`)!
+function getValue(id: string): HTMLElement {
+  return block.querySelector<HTMLElement>(`.is-${id}`)!
 }
 
 let freezeMax = getValue('freeze-max')
@@ -13,6 +23,83 @@ let workerMax = getValue('worker-max')
 let workerSum = getValue('worker-sum')
 let paint = getValue('paint')
 
+let runBtn = block.querySelector<HTMLButtonElement>('.benchmark_run')!
+let status = block.querySelector<HTMLSpanElement>('.benchmark_status')!
+
+const BATCH_N = 500
+const WARMUP_N = 10
+
+let statCells = (
+  [
+    ['paint', 'paint'],
+    ['wmax', 'workerMax'],
+    ['wsum', 'workerSum'],
+    ['fsum', 'freezeSum']
+  ] as [string, keyof FrameRecord][]
+).map(([id, key]) => ({
+  key,
+  median: getValue(`stat-${id}-median`),
+  p95: getValue(`stat-${id}-p95`)
+}))
+
+function fmt(n: number): string {
+  return n.toFixed(1)
+}
+
+function resetStats(): void {
+  for (let c of statCells) {
+    c.median.innerText = '—'
+    c.p95.innerText = '—'
+  }
+}
+
+function renderStats(history: readonly FrameRecord[]): void {
+  if (history.length === 0) {
+    resetStats()
+    return
+  }
+  for (let c of statCells) {
+    let s = computeStats(history.map(r => r[c.key]))
+    c.median.innerText = fmt(s.median)
+    c.p95.innerText = fmt(s.p95)
+  }
+}
+
+async function driveFrame(t: number): Promise<void> {
+  setCurrentComponents({
+    c: 0.05 + 0.2 * ((t * 7) % 1),
+    h: (t * 360 * 3) % 360,
+    l: 0.2 + 0.6 * t
+  })
+  await waitForWorkersIdle()
+  await new Promise(resolve => {
+    requestAnimationFrame(() => {
+      resolve(null)
+    })
+  })
+}
+
+async function runBatch(): Promise<void> {
+  runBtn.disabled = true
+  clearHistory()
+  resetStats()
+
+  for (let i = 0; i < BATCH_N; i++) {
+    status.innerText = `${i + 1} / ${BATCH_N}`
+    await driveFrame((i + 1) / BATCH_N)
+    if (i + 1 === WARMUP_N) clearHistory()
+  }
+
+  flushCurrentFrame()
+  renderStats(getHistory())
+  status.innerText = `done (${getHistory().length})`
+  runBtn.disabled = false
+}
+
+runBtn.addEventListener('click', () => {
+  void runBatch()
+})
+
 let unbind: (() => void) | undefined
 benchmarking.subscribe(enabled => {
   if (enabled) {
@@ -20,11 +107,11 @@ benchmarking.subscribe(enabled => {
     block.setAttribute('aria-hidden', 'false')
     unbind = lastBenchmark.subscribe(result => {
       block.style.setProperty('--benchmark-color', getLastBenchmarkColor())
-      freezeMax.innerText = `${result.freezeMax}`
-      freezeSum.innerText = `${result.freezeSum}`
-      workerMax.innerText = `${result.workerMax}`
-      workerSum.innerText = `${result.workerSum}`
-      paint.innerText = `${result.paint}`
+      freezeMax.innerText = fmt(result.freezeMax)
+      freezeSum.innerText = fmt(result.freezeSum)
+      workerMax.innerText = fmt(result.workerMax)
+      workerSum.innerText = fmt(result.workerSum)
+      paint.innerText = fmt(result.paint)
     })
   } else {
     block.classList.remove('is-enabled')

--- a/view/chart/worker.ts
+++ b/view/chart/worker.ts
@@ -22,7 +22,7 @@ export type PaintedData = {
 }
 
 onmessage = (e: MessageEvent<PaintData>) => {
-  let start = Date.now()
+  let start = performance.now()
 
   let image: ImageData
   if (e.data.type === 'l') {
@@ -66,7 +66,7 @@ onmessage = (e: MessageEvent<PaintData>) => {
   let message: PaintedData = {
     from: e.data.from,
     pixels: image.data.buffer,
-    time: Date.now() - start,
+    time: performance.now() - start,
     width: image.width
   }
   postMessage(message, [image.data.buffer])


### PR DESCRIPTION
Makes the `b` overlay reliable enough to compare branches side-by-side. Runs N color changes through the real async worker pipeline and reports median / p95 for each metric, instead of a single-frame sample.

- **Sub-ms timer** — swap `Date.now()` for `performance.now()` in the worker and the benchmark store; `Date.now()`'s 1 ms resolution was too coarse for sub-ms per-tile work
- **Frame ring buffer** — `stores/benchmark.ts` now keeps a history of up to 1000 completed frames instead of overwriting a single record; `startPainting()` flushes the prior frame on each call
- **Real-pipeline batch runner** — new **Run 500** button drives `setCurrentComponents` 500 times through the same async path a user drag hits (no sync shortcut); awaits worker idle + rAF between iterations
- **Worker idle primitive** — `lib/workers.ts` tracks in-flight workers and exposes `waitForWorkersIdle()`; no behavioural change to existing dispatch
- **Median / p95 table** — 4 metrics (Paint, Worker max, Worker sum, Freeze sum) × median / p95, populated from the collected frames
