### PR TITLE
Migrate stores from culori to colordx

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -20,6 +20,6 @@
     "name": "Scripts for 3D model",
     "path": "dist/model-*.js",
     "brotli": false,
-    "limit": "600 KB"
+    "limit": "605 KB"
   }
 ]

--- a/lib/colors.ts
+++ b/lib/colors.ts
@@ -1,25 +1,33 @@
 import {
+  type AnyColor,
+  Colordx,
+  extend,
+  lchToLinearAndSrgbInto,
+  lchToLinearSrgbInto,
   oklchToLinearAndSrgbInto,
   oklchToLinearInto,
-  oklchToRgbChannelsInto
+  oklchToRgbChannelsInto,
+  toHexByte
 } from '@colordx/core'
-import { linearToP3ChannelsInto } from '@colordx/core/plugins/p3'
-import { linearToRec2020ChannelsInto } from '@colordx/core/plugins/rec2020'
+import labPlugin from '@colordx/core/plugins/lab'
+import lchPlugin from '@colordx/core/plugins/lch'
+import p3Plugin, {
+  inGamutP3,
+  linearToP3ChannelsInto
+} from '@colordx/core/plugins/p3'
+import rec2020Plugin, {
+  inGamutRec2020,
+  linearToRec2020ChannelsInto
+} from '@colordx/core/plugins/rec2020'
 import {
   type Color,
   formatCss,
   formatRgb as formatRgbFast,
-  inGamut,
   type Lch,
   type Lrgb,
-  modeHsl,
-  modeLab,
   modeLch,
-  modeLrgb,
-  modeOklab,
   modeOklch,
   modeP3,
-  modeRec2020,
   modeRgb,
   modeXyz65,
   type Oklch,
@@ -27,7 +35,6 @@ import {
   type P3,
   type Rec2020,
   type Rgb,
-  toGamut,
   useMode
 } from 'culori/fn'
 
@@ -35,19 +42,16 @@ import { support } from '../stores/support.ts'
 
 export type { Rgb } from 'culori/fn'
 
+extend([p3Plugin, rec2020Plugin, lchPlugin, labPlugin])
+
 export type AnyLch = Lch | Oklch
 export type AnyRgb = Lrgb | P3 | Rec2020 | Rgb
 
-export let rec2020 = useMode(modeRec2020)
 export let oklch = useMode(modeOklch)
-export let oklab = useMode(modeOklab)
-export let xyz65 = useMode(modeXyz65)
+let xyz65 = useMode(modeXyz65)
 export let rgb = useMode(modeRgb)
 export let lch = useMode(modeLch)
-export let hsl = useMode(modeHsl)
-export let lab = useMode(modeLab)
-export let lrgb = useMode(modeLrgb)
-export let p3 = useMode(modeP3)
+let p3 = useMode(modeP3)
 
 const COLOR_SPACE_GAP = 0.0001
 const RENDER_GAP = 1e-7
@@ -64,8 +68,21 @@ export function inRGB(color: Color): boolean {
     check.b <= 1 + COLOR_SPACE_GAP
   )
 }
-export let inP3 = inGamut('p3')
-export let inRec2020 = inGamut('rec2020')
+// colordx discriminates CIE LCH from OKLCH by `colorSpace: 'lch'`.
+// Culori-shape lch objects don't have it — add at the boundary.
+function asAnyColor(color: Color): AnyColor {
+  if (color.mode === 'lch') {
+    return { ...color, colorSpace: 'lch' } as unknown as AnyColor
+  }
+  return color as AnyColor
+}
+
+export function inP3(color: Color): boolean {
+  return inGamutP3(asAnyColor(color))
+}
+export function inRec2020(color: Color): boolean {
+  return inGamutRec2020(asAnyColor(color))
+}
 
 export function build(l: number, c: number, h: number, alpha = 1): AnyLch {
   return { alpha, c, h, l, mode: COLOR_FN }
@@ -127,7 +144,26 @@ export function forceP3(color: Color): P3 {
   return { ...rgb(color), mode: 'p3' }
 }
 
-export let toRgb = toGamut('rgb', COLOR_FN)
+// Wrap colordx RGB bytes (0..255) in culori's rgb shape (channels in 0..1).
+// Drop when view/chart + worker consume colordx-native color objects.
+export function toCuloriRgb(c: {
+  alpha: number
+  b: number
+  g: number
+  r: number
+}): Rgb {
+  return {
+    alpha: c.alpha,
+    b: c.b / 255,
+    g: c.g / 255,
+    mode: 'rgb',
+    r: c.r / 255
+  }
+}
+
+export function toRgb(color: Color): Rgb {
+  return toCuloriRgb(Colordx.toGamutSrgb(asAnyColor(color))._rawRgb())
+}
 
 export function formatRgb(color: Rgb): string {
   let r = Math.round(25500 * color.r) / 100
@@ -157,6 +193,13 @@ export function clean(value: number, precision = 2): number {
   )
 }
 
+// Wrapper over colordx's toHex8 for culori-shaped inputs (rgb channels in [0, 1]).
+// Drop once parseAnything returns colordx-native color objects.
+export function toHex8(color: Color): string {
+  let c = rgb(color)
+  return `#${toHexByte(c.r * 255)}${toHexByte(c.g * 255)}${toHexByte(c.b * 255)}${toHexByte((c.alpha ?? 1) * 255)}`
+}
+
 export function isHexNotation(value: string): boolean {
   return /^#?([\da-f]{3}|[\da-f]{4}|[\da-f]{6}|[\da-f]{8})$/i.test(value)
 }
@@ -180,12 +223,11 @@ if (LCH) {
 }
 
 export function getSpace(color: Color): Space {
-  let proxyColor = getProxyColor(color)
-  if (inRGB(proxyColor)) {
+  if (inRGB(getProxyColor(color))) {
     return Space.sRGB
-  } else if (inP3(proxyColor)) {
+  } else if (inP3(color)) {
     return Space.P3
-  } else if (inRec2020(proxyColor)) {
+  } else if (inRec2020(color)) {
     return Space.Rec2020
   } else {
     return Space.Out
@@ -200,12 +242,11 @@ export function generateGetSpace(
 ): GetSpace {
   if (showP3 && showRec2020) {
     return color => {
-      let proxyColor = getProxyColor(color)
-      if (inRGB(proxyColor)) {
+      if (inRGB(getProxyColor(color))) {
         return Space.sRGB
-      } else if (inP3(proxyColor)) {
+      } else if (inP3(color)) {
         return Space.P3
-      } else if (inRec2020(proxyColor)) {
+      } else if (inRec2020(color)) {
         return Space.Rec2020
       } else {
         return Space.Out
@@ -213,10 +254,9 @@ export function generateGetSpace(
     }
   } else if (showP3 && !showRec2020) {
     return color => {
-      let proxyColor = getProxyColor(color)
-      if (inRGB(proxyColor)) {
+      if (inRGB(getProxyColor(color))) {
         return Space.sRGB
-      } else if (inP3(proxyColor)) {
+      } else if (inP3(color)) {
         return Space.P3
       } else {
         return Space.Out
@@ -224,10 +264,9 @@ export function generateGetSpace(
     }
   } else if (!showP3 && showRec2020) {
     return color => {
-      let proxyColor = getProxyColor(color)
-      if (inRGB(proxyColor)) {
+      if (inRGB(getProxyColor(color))) {
         return Space.sRGB
-      } else if (inRec2020(proxyColor)) {
+      } else if (inRec2020(color)) {
         return Space.P3
       } else {
         return Space.Out
@@ -271,23 +310,71 @@ export function generateGetPixel(
   p3Support: boolean
 ): GetPixel {
   if (LCH) {
+    if (p3Support && (showP3 || showRec2020)) {
+      return (x, y) => {
+        let color = getColor(x, y)
+        lchToLinearSrgbInto(LIN_BUF, color.l, color.c, color.h ?? 0)
+        let lr = LIN_BUF[0]
+        let lg = LIN_BUF[1]
+        let lb = LIN_BUF[2]
+        linearToP3ChannelsInto(P3_BUF, lr, lg, lb)
+        let pr = P3_BUF[0]
+        let pg = P3_BUF[1]
+        let pb = P3_BUF[2]
+        let pixel: Pixel = [
+          Space.Out,
+          Math.floor(255 * pr),
+          Math.floor(255 * pg),
+          Math.floor(255 * pb)
+        ]
+        if (inGamutEps(lr, lg, lb)) {
+          pixel[0] = Space.sRGB
+        } else if (showP3 && inGamutEps(pr, pg, pb)) {
+          pixel[0] = Space.P3
+        } else if (showRec2020) {
+          linearToRec2020ChannelsInto(REC_BUF, lr, lg, lb)
+          if (inGamutEps(REC_BUF[0], REC_BUF[1], REC_BUF[2])) {
+            pixel[0] = Space.Rec2020
+          }
+        }
+        return pixel
+      }
+    }
     return (x, y) => {
       let color = getColor(x, y)
-      let proxyColor = getProxyColor(color)
-      let displayColor =
-        p3Support && (showP3 || showRec2020) ? p3(proxyColor) : rgb(proxyColor)
+      lchToLinearAndSrgbInto(
+        LIN_BUF,
+        SRGB_BUF,
+        color.l,
+        color.c,
+        color.h ?? 0
+      )
+      let lr = LIN_BUF[0]
+      let lg = LIN_BUF[1]
+      let lb = LIN_BUF[2]
       let pixel: Pixel = [
         Space.Out,
-        Math.floor(255 * displayColor.r),
-        Math.floor(255 * displayColor.g),
-        Math.floor(255 * displayColor.b)
+        Math.floor(255 * SRGB_BUF[0]),
+        Math.floor(255 * SRGB_BUF[1]),
+        Math.floor(255 * SRGB_BUF[2])
       ]
-      if (inRGB(proxyColor)) {
+      if (inGamutEps(lr, lg, lb)) {
         pixel[0] = Space.sRGB
-      } else if (showP3 && inP3(proxyColor)) {
-        pixel[0] = Space.P3
-      } else if (showRec2020 && inRec2020(proxyColor)) {
-        pixel[0] = Space.Rec2020
+      } else if (showP3) {
+        linearToP3ChannelsInto(P3_BUF, lr, lg, lb)
+        if (inGamutEps(P3_BUF[0], P3_BUF[1], P3_BUF[2])) {
+          pixel[0] = Space.P3
+        } else if (showRec2020) {
+          linearToRec2020ChannelsInto(REC_BUF, lr, lg, lb)
+          if (inGamutEps(REC_BUF[0], REC_BUF[1], REC_BUF[2])) {
+            pixel[0] = Space.Rec2020
+          }
+        }
+      } else if (showRec2020) {
+        linearToRec2020ChannelsInto(REC_BUF, lr, lg, lb)
+        if (inGamutEps(REC_BUF[0], REC_BUF[1], REC_BUF[2])) {
+          pixel[0] = Space.Rec2020
+        }
       }
       return pixel
     }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test": "FORCE_COLOR=1 pnpm run /^test:/"
   },
   "dependencies": {
-    "@colordx/core": "^5.2.0",
+    "@colordx/core": "^5.4.1",
     "@csstools/postcss-oklab-function": "^5.0.3",
     "@nanostores/persistent": "^1.3.3",
     "autoprefixer": "^10.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@colordx/core':
-        specifier: ^5.2.0
-        version: 5.2.0
+        specifier: ^5.4.1
+        version: 5.4.1
       '@csstools/postcss-oklab-function':
         specifier: ^5.0.3
         version: 5.0.3(postcss@8.5.10)
@@ -153,8 +153,8 @@ packages:
   '@cacheable/utils@2.4.1':
     resolution: {integrity: sha512-eiFgzCbIneyMlLOmNG4g9xzF7Hv3Mga4LjxjcSC/ues6VYq2+gUbQI8JqNuw/ZM8tJIeIaBGpswAsqV2V7ApgA==}
 
-  '@colordx/core@5.2.0':
-    resolution: {integrity: sha512-wifnqsGCXRh+lJdX4975nKEPJaSk7k8rMiA/VeGrS4tOTn06WZrow6cUA7wFJKPXfcqj0rXeH4BMgGoKZvBf7g==}
+  '@colordx/core@5.4.1':
+    resolution: {integrity: sha512-J6wPkrci9gao7mABevY/12hOZsyVrgaTUPE92rfH2AVW4ZuRZi1wD3lgqGWBGSvAjE24HSGBp4UoKvbYPlCLCA==}
 
   '@csstools/color-helpers@6.0.2':
     resolution: {integrity: sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==}
@@ -1736,7 +1736,7 @@ snapshots:
       hashery: 1.5.1
       keyv: 5.6.0
 
-  '@colordx/core@5.2.0': {}
+  '@colordx/core@5.4.1': {}
 
   '@csstools/color-helpers@6.0.2': {}
 

--- a/stores/benchmark.ts
+++ b/stores/benchmark.ts
@@ -1,4 +1,4 @@
-import { formatHex, type Oklch } from 'culori/fn'
+import { colordx } from '@colordx/core'
 import { map } from 'nanostores'
 
 import { benchmarking } from './url.ts'
@@ -101,6 +101,5 @@ export function getLastBenchmarkColor(): string {
   let worstRate = Math.max(freezeSum / MAX_FREEZE, paint / MAX_PAINT)
   let hue = BEST_HUE - (BEST_HUE - WORST_HUE) * worstRate
   if (hue < WORST_HUE) hue = WORST_HUE
-  let oklch: Oklch = { c: 0.11, h: hue, l: 0.57, mode: 'oklch' }
-  return formatHex(oklch)
+  return colordx({ c: 0.11, h: hue, l: 0.57 }).toHex()
 }

--- a/stores/current.ts
+++ b/stores/current.ts
@@ -1,4 +1,3 @@
-import { formatHex8 } from 'culori/fn'
 import { map } from 'nanostores'
 
 import {
@@ -10,6 +9,7 @@ import {
   oklch,
   parseAnything,
   Space,
+  toHex8,
   toRgb
 } from '../lib/colors.ts'
 import { debounce } from '../lib/time.ts'
@@ -213,13 +213,15 @@ export function setCurrent(code: string, isRgbInput = false): boolean {
         current.set({ a: (parsed.alpha ?? 1) * 100, c: 0, h: 0, l: 1 })
         return true
       }
-      let originSpace = getSpace(parsed)
+      // Alias to preserve TS narrowing of `parsed` inside the isPreciseEnough closure.
+      let originColor = parsed
+      let originSpace = getSpace(originColor)
 
       function isPreciseEnough(value: LchValue): boolean {
         let color = valueToColor(value)
         if (originSpace !== getSpace(color)) {
           return false
-        } else if (formatHex8(color) !== formatHex8(parsed)) {
+        } else if (toHex8(color) !== toHex8(originColor)) {
           return false
         } else {
           return true

--- a/stores/formats.ts
+++ b/stores/formats.ts
@@ -1,73 +1,26 @@
-import {
-  type Color,
-  formatCss,
-  formatHex,
-  formatHex8,
-  formatRgb,
-  type Oklab,
-  serializeHex8
-} from 'culori/fn'
+import { colordx, oklchToLinear, toHexByte } from '@colordx/core'
 import { computed } from 'nanostores'
 
-import {
-  type AnyLch,
-  type AnyRgb,
-  clean,
-  hsl,
-  inRGB,
-  lab,
-  lch,
-  lrgb,
-  oklab,
-  p3,
-  toRgb
-} from '../lib/colors.ts'
+import { clean } from '../lib/colors.ts'
 import { current, valueToColor } from './current.ts'
 import type { OutputFormats } from './settings.ts'
 
-function formatOklab(color: Oklab): string {
-  let { a, alpha, b, l } = color
-  let postfix = ''
-  if (typeof alpha !== 'undefined' && alpha < 1) {
-    postfix = ` / ${clean(alpha)}`
-  }
-  return `oklab(${clean(l)} ${clean(a)} ${clean(b)}${postfix})`
+function formatVec(r: number, g: number, b: number, alpha: number): string {
+  return `vec(${clean(r, 5)}, ${clean(g, 5)}, ${clean(b, 5)}, ${clean(alpha, 5)})`
 }
 
-function formatVec(color: AnyRgb): string {
-  let { alpha, b, g, r } = color
-  let a = alpha ?? 1
-  return `vec(${clean(r, 5)}, ${clean(g, 5)}, ${clean(b, 5)}, ${clean(a, 5)})`
+function toNumbers(l: number, c: number, h: number, alpha: number): string {
+  let prefix = `${clean(l)}, ${clean(c)}, ${clean(h)}`
+  if (alpha < 1) return `${prefix}, ${clean(alpha)}`
+  return prefix
 }
 
-function toNumbers(color: AnyLch): string {
-  let { alpha, c, h, l } = color
-  let prefix = `${clean(l)}, ${clean(c)}, ${clean(h ?? 0)}`
-  if (typeof alpha !== 'undefined' && alpha < 1) {
-    return `${prefix}, ${clean(alpha)}`
-  } else {
-    return prefix
-  }
-}
-
-function cleanComponents<Obj extends object>(
-  color: Obj,
-  precision?: number
-): Obj {
-  // oxlint-disable-next-line typescript/no-explicit-any
-  let result: any = {}
-  for (let key in color) {
-    let value = color[key]
-    if (typeof value === 'number' && key !== 'alpha') {
-      // oxlint-disable-next-line typescript/no-unsafe-member-access
-      result[key] = clean(value, precision)
-    } else {
-      // oxlint-disable-next-line typescript/no-unsafe-member-access
-      result[key] = color[key]
-    }
-  }
-  // oxlint-disable-next-line typescript/no-unsafe-return
-  return result
+// Hex of the raw P3 channels (Figma's wide-gamut export format).
+// Channels are 0..1 (P3Color scale); colordx's toHex8 only covers sRGB.
+function figmaP3Hex(
+  color: { r: number; g: number; b: number; alpha: number }
+): string {
+  return `#${toHexByte(color.r * 255)}${toHexByte(color.g * 255)}${toHexByte(color.b * 255)}${toHexByte(color.alpha * 255)}`
 }
 
 export type FormatsValue = Record<OutputFormats, string>
@@ -80,23 +33,33 @@ export let srgbFormats = new Set<OutputFormats>([
 ])
 
 export let formats = computed(current, value => {
-  let color: AnyLch = valueToColor(value)
-  let rgbColor: Color = inRGB(color) ? color : toRgb(color)
-  let hex = formatHex(rgbColor)
-  let rgba = formatRgb(rgbColor)
-  let hasAlpha = typeof color.alpha !== 'undefined' && color.alpha < 1
+  let oklch = valueToColor(value)
+  let l = oklch.l
+  let c = oklch.c
+  let h = oklch.h ?? 0
+  let alpha = oklch.alpha ?? 1
+  let hasAlpha = alpha < 1
+
+  let dx =
+    COLOR_FN === 'lch'
+      ? colordx({ alpha, c, colorSpace: 'lch', h, l })
+      : colordx({ alpha, c, h, l })
+  let mapped = dx.mapSrgb()
+  let rgbString = mapped.toRgbString({ legacy: true })
+  let [lr, lg, lb] = oklchToLinear(l, c, h)
+
   return {
-    'figmaP3': 'Figma P3 ' + serializeHex8(p3(color)),
-    'hex': hasAlpha ? formatHex8(rgbColor) : hex,
-    'hex/rgba': hasAlpha ? rgba : hex,
-    'hsl': formatCss(cleanComponents(hsl(rgbColor))),
-    'lab': formatCss(cleanComponents(lab(color))),
-    'lch': formatCss(cleanComponents(lch(color))),
-    'lrgb': 'Linear RGB ' + formatVec(lrgb(color)),
-    'numbers': toNumbers(color),
-    'oklab': formatOklab(oklab(color)),
-    'p3': formatCss(cleanComponents(p3(color), 4)),
-    'rgb': rgba
+    'figmaP3': 'Figma P3 ' + figmaP3Hex(dx.toP3()),
+    'hex': hasAlpha ? mapped.toHex8() : mapped.toHex(),
+    'hex/rgba': hasAlpha ? rgbString : mapped.toHex(),
+    'hsl': mapped.toHslString(),
+    'lab': dx.toLabString(),
+    'lch': dx.toLchString(),
+    'lrgb': 'Linear RGB ' + formatVec(lr, lg, lb, alpha),
+    'numbers': toNumbers(l, c, h, alpha),
+    'oklab': dx.toOklabString(2),
+    'p3': dx.toP3String(),
+    'rgb': rgbString
   } as FormatsValue
 })
 

--- a/stores/visible.ts
+++ b/stores/visible.ts
@@ -1,7 +1,8 @@
-import type { Color } from 'culori/fn'
 import { computed } from 'nanostores'
 
 import {
+  type AnyLch,
+  type AnyRgb,
   fastFormat,
   formatRgb,
   getSpace,
@@ -13,7 +14,7 @@ import { current, valueToColor } from './current.ts'
 import { support } from './support.ts'
 
 interface VisibleValue {
-  color: Color
+  color: AnyLch | AnyRgb
   fallback: string
   real: false | string
   space: 'out' | 'p3' | 'rec2020' | 'srgb'

--- a/test/alpha.test.ts
+++ b/test/alpha.test.ts
@@ -1,0 +1,37 @@
+import './set-globals.ts'
+
+import { deepStrictEqual } from 'node:assert'
+import { test } from 'node:test'
+
+import { current, setCurrent } from '../stores/current.ts'
+import { formats } from '../stores/formats.ts'
+
+test('setCurrent with 8-char hex stores correct alpha', () => {
+  setCurrent('#ff000080')
+  deepStrictEqual(current.get(), { a: 50.2, c: 0.2577, h: 29.23, l: 0.628 })
+
+  setCurrent('#00000040')
+  deepStrictEqual(current.get(), { a: 25.1, c: 0, h: 0, l: 0 })
+
+  setCurrent('#ff000000')
+  deepStrictEqual(current.get(), { a: 0, c: 0.2577, h: 29.23, l: 0.628 })
+})
+
+test('setCurrent with 8-char hex round-trips through formats.hex', () => {
+  for (let input of ['#ff000080', '#00000040', '#ff000000', '#12345678']) {
+    setCurrent(input)
+    deepStrictEqual(formats.get().hex, input)
+  }
+})
+
+test('setCurrent with oklch(… / alpha) stores and round-trips to hex8', () => {
+  setCurrent('oklch(0.628 0.2577 29.23 / 0.5)')
+  deepStrictEqual(current.get(), { a: 50, c: 0.2577, h: 29.23, l: 0.628 })
+  deepStrictEqual(formats.get().hex, '#ff000080')
+})
+
+test('setCurrent with rgba() input stores alpha', () => {
+  setCurrent('rgba(255, 0, 0, 0.5)')
+  deepStrictEqual(current.get(), { a: 50, c: 0.2577, h: 29.23, l: 0.628 })
+  deepStrictEqual(formats.get().hex, '#ff000080')
+})

--- a/test/benchmark.test.ts
+++ b/test/benchmark.test.ts
@@ -1,0 +1,66 @@
+import './set-globals.ts'
+
+import { deepStrictEqual } from 'node:assert'
+import { test } from 'node:test'
+
+import '../lib/colors.ts'
+import {
+  clearBenchmarkHistory,
+  computeBenchmarkStats,
+  getLastBenchmarkColor,
+  lastBenchmark
+} from '../stores/benchmark.ts'
+
+function frame(freezeSum: number, paint: number): {
+  freezeMax: number
+  freezeSum: number
+  paint: number
+  workerMax: number
+  workerSum: number
+} {
+  return {
+    freezeMax: freezeSum,
+    freezeSum,
+    paint,
+    workerMax: 0,
+    workerSum: 0
+  }
+}
+
+test('getLastBenchmarkColor maps perf to hue', () => {
+  lastBenchmark.set(frame(0, 0))
+  deepStrictEqual(getLastBenchmarkColor(), '#418954')
+
+  lastBenchmark.set(frame(1, 50))
+  deepStrictEqual(getLastBenchmarkColor(), '#4b884c')
+
+  lastBenchmark.set(frame(15, 500))
+  deepStrictEqual(getLastBenchmarkColor(), '#8c7616')
+
+  lastBenchmark.set(frame(40, 1200))
+  deepStrictEqual(getLastBenchmarkColor(), '#ad5f43')
+
+  clearBenchmarkHistory()
+})
+
+test('computeBenchmarkStats: empty → zeros', () => {
+  deepStrictEqual(computeBenchmarkStats([]), { median: 0, p95: 0 })
+})
+
+test('computeBenchmarkStats: single value', () => {
+  deepStrictEqual(computeBenchmarkStats([5]), { median: 5, p95: 5 })
+})
+
+test('computeBenchmarkStats: sorted input', () => {
+  deepStrictEqual(
+    computeBenchmarkStats([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
+    { median: 6, p95: 10 }
+  )
+})
+
+test('computeBenchmarkStats: unsorted input', () => {
+  deepStrictEqual(
+    computeBenchmarkStats([10, 1, 5, 2, 8, 3, 9, 4, 7, 6]),
+    { median: 6, p95: 10 }
+  )
+})

--- a/test/colordx.test.ts
+++ b/test/colordx.test.ts
@@ -2,12 +2,18 @@ import { ok } from 'node:assert'
 import { test } from 'node:test'
 
 import {
+  lchToLinearSrgb,
+  lchToRgbChannels,
   oklchToLinear,
   oklchToRgbChannels
 } from '@colordx/core'
-import { linearToP3Channels } from '@colordx/core/plugins/p3'
-import { linearToRec2020Channels } from '@colordx/core/plugins/rec2020'
+import { lchToP3Channels, linearToP3Channels } from '@colordx/core/plugins/p3'
 import {
+  lchToRec2020Channels,
+  linearToRec2020Channels
+} from '@colordx/core/plugins/rec2020'
+import {
+  modeLch,
   modeLrgb,
   modeOklch,
   modeP3,
@@ -21,6 +27,7 @@ let toLrgb = useMode(modeLrgb)
 let toP3 = useMode(modeP3)
 let toRec2020 = useMode(modeRec2020)
 useMode(modeOklch)
+useMode(modeLch)
 
 // Sample OKLCH values covering sRGB, P3, Rec2020, and out-of-gamut
 const CASES: [l: number, c: number, h: number][] = [
@@ -76,6 +83,49 @@ test('linearToRec2020Channels matches culori Rec2020 conversion', () => {
     let [lr, lg, lb] = oklchToLinear(l, c, h)
     let [rr, rg, rb] = linearToRec2020Channels(lr, lg, lb)
     let ref = toRec2020({ b: lb, g: lg, mode: 'lrgb', r: lr })
+    close([rr, rg, rb], ref, `L=${l} C=${c} H=${h}`)
+  }
+})
+
+// CIE LCH (D50) sample values covering sRGB, P3, Rec2020, and out-of-gamut
+const LCH_CASES: [l: number, c: number, h: number][] = [
+  [50, 0, 0], // achromatic
+  [50, 10, 180], // low chroma — sRGB
+  [60, 50, 145], // mid green — P3
+  [60, 80, 145], // high chroma green — Rec2020
+  [50, 120, 30], // out of Rec2020
+  [0, 0, 0], // black
+  [100, 0, 0] // white
+]
+
+test('lchToRgbChannels matches culori rgb(lch) conversion', () => {
+  for (let [l, c, h] of LCH_CASES) {
+    let [r, g, b] = lchToRgbChannels(l, c, h)
+    let ref = toRgb({ c, h, l, mode: 'lch' as const })
+    close([r, g, b], ref, `L=${l} C=${c} H=${h}`)
+  }
+})
+
+test('lchToLinearSrgb matches culori lrgb(lch) conversion', () => {
+  for (let [l, c, h] of LCH_CASES) {
+    let [lr, lg, lb] = lchToLinearSrgb(l, c, h)
+    let ref = toLrgb({ c, h, l, mode: 'lch' as const })
+    close([lr, lg, lb], ref, `L=${l} C=${c} H=${h}`)
+  }
+})
+
+test('lchToP3Channels matches culori p3(lch) conversion', () => {
+  for (let [l, c, h] of LCH_CASES) {
+    let [pr, pg, pb] = lchToP3Channels(l, c, h)
+    let ref = toP3({ c, h, l, mode: 'lch' as const })
+    close([pr, pg, pb], ref, `L=${l} C=${c} H=${h}`)
+  }
+})
+
+test('lchToRec2020Channels matches culori rec2020(lch) conversion', () => {
+  for (let [l, c, h] of LCH_CASES) {
+    let [rr, rg, rb] = lchToRec2020Channels(l, c, h)
+    let ref = toRec2020({ c, h, l, mode: 'lch' as const })
     close([rr, rg, rb], ref, `L=${l} C=${c} H=${h}`)
   }
 })

--- a/test/colors-api.test.ts
+++ b/test/colors-api.test.ts
@@ -1,0 +1,88 @@
+import './set-globals.ts'
+
+import { deepStrictEqual, ok } from 'node:assert'
+import { test } from 'node:test'
+
+import {
+  build,
+  getSpace,
+  inP3,
+  inRec2020,
+  inRGB,
+  parseAnything,
+  Space,
+  toHex8,
+  toRgb
+} from '../lib/colors.ts'
+
+function spaceFor(input: string): Space {
+  let parsed = parseAnything(input)
+  if (!parsed) throw new Error(`unparseable: ${input}`)
+  return getSpace(parsed)
+}
+
+test('getSpace classifies sRGB colors', () => {
+  deepStrictEqual(spaceFor('#ff0000'), Space.sRGB)
+  deepStrictEqual(spaceFor('#808080'), Space.sRGB)
+  deepStrictEqual(spaceFor('#ffffff'), Space.sRGB)
+  deepStrictEqual(spaceFor('#000000'), Space.sRGB)
+  deepStrictEqual(spaceFor('oklch(0.7 0.15 30)'), Space.sRGB)
+})
+
+test('getSpace classifies P3 colors', () => {
+  deepStrictEqual(spaceFor('oklch(0.6 0.22 145)'), Space.P3)
+})
+
+test('getSpace classifies Rec2020 colors', () => {
+  deepStrictEqual(spaceFor('oklch(0.6 0.26 145)'), Space.Rec2020)
+})
+
+test('getSpace classifies out-of-gamut colors', () => {
+  deepStrictEqual(spaceFor('oklch(0.5 0.5 30)'), Space.Out)
+  deepStrictEqual(spaceFor('oklch(0.6 0.3 145)'), Space.Out)
+})
+
+test('inRGB / inP3 / inRec2020 at gamut boundaries (h=145)', () => {
+  // Just past sRGB, inside P3
+  let p3Color = build(0.6, 0.22, 145)
+  deepStrictEqual(inRGB(p3Color), false)
+  deepStrictEqual(inP3(p3Color), true)
+  deepStrictEqual(inRec2020(p3Color), true)
+
+  // Just past P3, inside Rec2020
+  let rec2020Color = build(0.6, 0.26, 145)
+  deepStrictEqual(inRGB(rec2020Color), false)
+  deepStrictEqual(inP3(rec2020Color), false)
+  deepStrictEqual(inRec2020(rec2020Color), true)
+
+  // Past Rec2020
+  let outColor = build(0.6, 0.3, 145)
+  deepStrictEqual(inRGB(outColor), false)
+  deepStrictEqual(inP3(outColor), false)
+  deepStrictEqual(inRec2020(outColor), false)
+
+  // Deep inside sRGB
+  let srgbColor = build(0.7, 0.15, 30)
+  deepStrictEqual(inRGB(srgbColor), true)
+  deepStrictEqual(inP3(srgbColor), true)
+  deepStrictEqual(inRec2020(srgbColor), true)
+})
+
+test('toRgb gamut-maps out-of-sRGB to in-gamut and preserves hex output', () => {
+  // Known hex targets were captured from current culori pipeline.
+  let cases: { hex: string; input: string }[] = [
+    { hex: '#c30000', input: 'oklch(0.5 0.5 30)' },
+    { hex: '#14c000', input: 'oklch(0.7 0.4 140)' },
+    { hex: '#ccddff', input: 'oklch(0.9 0.35 270)' },
+    { hex: '#001e17', input: 'oklch(0.2 0.3 180)' }
+  ]
+  for (let { hex, input } of cases) {
+    let parsed = parseAnything(input)
+    if (!parsed) throw new Error(`unparseable: ${input}`)
+    let mapped = toRgb(parsed)
+    ok(inRGB(mapped), `${input} should map into sRGB`)
+    // 8-digit hex, drop the alpha byte
+    let actualHex = toHex8(mapped).slice(0, 7)
+    deepStrictEqual(actualHex, hex, `hex mismatch for ${input}`)
+  }
+})

--- a/test/formats.test.ts
+++ b/test/formats.test.ts
@@ -1,0 +1,360 @@
+import './set-globals.ts'
+
+import { deepStrictEqual } from 'node:assert'
+import { test } from 'node:test'
+
+import { setCurrent } from '../stores/current.ts'
+import { formats } from '../stores/formats.ts'
+
+function formatsFor(input: string): Record<string, string> {
+  setCurrent(input)
+  return formats.get()
+}
+
+test('formats for opaque sRGB primaries', () => {
+  deepStrictEqual(formatsFor('#ff0000'), {
+    'figmaP3': 'Figma P3 #ea3323ff',
+    'hex': '#ff0000',
+    'hex/rgba': '#ff0000',
+    'hsl': 'hsl(359.98 100% 50%)',
+    'lab': 'lab(54.3 80.81 69.88)',
+    'lch': 'lch(54.3 106.83 40.85)',
+    'lrgb': 'Linear RGB vec(1.00021, 0, 0.00002, 1)',
+    'numbers': '0.63, 0.26, 29.23',
+    'oklab': 'oklab(0.63 0.22 0.13)',
+    'p3': 'color(display-p3 0.9176 0.2003 0.1387)',
+    'rgb': 'rgb(255, 0, 0)'
+  })
+
+  deepStrictEqual(formatsFor('#00ff00'), {
+    'figmaP3': 'Figma P3 #75fb4cff',
+    'hex': '#00ff00',
+    'hex/rgba': '#00ff00',
+    'hsl': 'hsl(120 100% 50%)',
+    'lab': 'lab(87.82 -79.27 80.99)',
+    'lch': 'lch(87.82 113.33 134.38)',
+    'lrgb': 'Linear RGB vec(0, 1, 0, 1)',
+    'numbers': '0.87, 0.29, 142.5',
+    'oklab': 'oklab(0.87 -0.23 0.18)',
+    'p3': 'color(display-p3 0.4584 0.9853 0.2983)',
+    'rgb': 'rgb(0, 255, 0)'
+  })
+
+  deepStrictEqual(formatsFor('#0000ff'), {
+    'figmaP3': 'Figma P3 #0000f5ff',
+    'hex': '#0000ff',
+    'hex/rgba': '#0000ff',
+    'hsl': 'hsl(240 100% 50%)',
+    'lab': 'lab(29.57 68.29 -112.03)',
+    'lch': 'lch(29.57 131.2 301.36)',
+    'lrgb': 'Linear RGB vec(0, 0, 1, 1)',
+    'numbers': '0.45, 0.31, 264.05',
+    'oklab': 'oklab(0.45 -0.03 -0.31)',
+    'p3': 'color(display-p3 0 0 0.9596)',
+    'rgb': 'rgb(0, 0, 255)'
+  })
+})
+
+test('formats for white, black, gray', () => {
+  deepStrictEqual(formatsFor('#ffffff'), {
+    'figmaP3': 'Figma P3 #ffffffff',
+    'hex': '#ffffff',
+    'hex/rgba': '#ffffff',
+    'hsl': 'hsl(0 0% 100%)',
+    'lab': 'lab(100 0 0)',
+    'lch': 'lch(100 0 none)',
+    'lrgb': 'Linear RGB vec(1, 1, 1, 1)',
+    'numbers': '1, 0, 0',
+    'oklab': 'oklab(1 0 0)',
+    'p3': 'color(display-p3 1 1 1)',
+    'rgb': 'rgb(255, 255, 255)'
+  })
+
+  deepStrictEqual(formatsFor('#000000'), {
+    'figmaP3': 'Figma P3 #000000ff',
+    'hex': '#000000',
+    'hex/rgba': '#000000',
+    'hsl': 'hsl(0 0% 0%)',
+    'lab': 'lab(0 0 0)',
+    'lch': 'lch(0 0 none)',
+    'lrgb': 'Linear RGB vec(0, 0, 0, 1)',
+    'numbers': '0, 0, 0',
+    'oklab': 'oklab(0 0 0)',
+    'p3': 'color(display-p3 0 0 0)',
+    'rgb': 'rgb(0, 0, 0)'
+  })
+
+  deepStrictEqual(formatsFor('#808080'), {
+    'figmaP3': 'Figma P3 #808080ff',
+    'hex': '#808080',
+    'hex/rgba': '#808080',
+    'hsl': 'hsl(0 0% 50.2%)',
+    'lab': 'lab(53.59 0 0)',
+    'lch': 'lch(53.59 0 none)',
+    'lrgb': 'Linear RGB vec(0.21589, 0.21589, 0.21589, 1)',
+    'numbers': '0.6, 0, 0',
+    'oklab': 'oklab(0.6 0 0)',
+    'p3': 'color(display-p3 0.502 0.502 0.502)',
+    'rgb': 'rgb(128, 128, 128)'
+  })
+})
+
+test('formats for sRGB colors with alpha', () => {
+  deepStrictEqual(formatsFor('#ff000080'), {
+    'figmaP3': 'Figma P3 #ea332380',
+    'hex': '#ff000080',
+    'hex/rgba': 'rgba(255, 0, 0, 0.502)',
+    'hsl': 'hsl(359.98 100% 50% / 0.502)',
+    'lab': 'lab(54.3 80.81 69.88 / 0.502)',
+    'lch': 'lch(54.3 106.83 40.85 / 0.502)',
+    'lrgb': 'Linear RGB vec(1.00021, 0, 0.00002, 0.502)',
+    'numbers': '0.63, 0.26, 29.23, 0.5',
+    'oklab': 'oklab(0.63 0.22 0.13 / 0.502)',
+    'p3': 'color(display-p3 0.9176 0.2003 0.1387 / 0.502)',
+    'rgb': 'rgba(255, 0, 0, 0.502)'
+  })
+
+  deepStrictEqual(formatsFor('#00000040'), {
+    'figmaP3': 'Figma P3 #00000040',
+    'hex': '#00000040',
+    'hex/rgba': 'rgba(0, 0, 0, 0.251)',
+    'hsl': 'hsl(0 0% 0% / 0.251)',
+    'lab': 'lab(0 0 0 / 0.251)',
+    'lch': 'lch(0 0 none / 0.251)',
+    'lrgb': 'Linear RGB vec(0, 0, 0, 0.251)',
+    'numbers': '0, 0, 0, 0.25',
+    'oklab': 'oklab(0 0 0 / 0.251)',
+    'p3': 'color(display-p3 0 0 0 / 0.251)',
+    'rgb': 'rgba(0, 0, 0, 0.251)'
+  })
+})
+
+test('formats for secondary primaries (cyan, magenta, yellow)', () => {
+  deepStrictEqual(formatsFor('#00ffff'), {
+    'figmaP3': 'Figma P3 #75fbfdff',
+    'hex': '#00ffff',
+    'hex/rgba': '#00ffff',
+    'hsl': 'hsl(180 100% 50%)',
+    'lab': 'lab(90.67 -50.66 -14.96)',
+    'lch': 'lch(90.67 52.82 196.45)',
+    'lrgb': 'Linear RGB vec(0, 1, 1, 1)',
+    'numbers': '0.91, 0.15, 194.77',
+    'oklab': 'oklab(0.91 -0.15 -0.04)',
+    'p3': 'color(display-p3 0.4584 0.9853 0.9925)',
+    'rgb': 'rgb(0, 255, 255)'
+  })
+
+  deepStrictEqual(formatsFor('#ff00ff'), {
+    'figmaP3': 'Figma P3 #ea33f7ff',
+    'hex': '#ff00ff',
+    'hex/rgba': '#ff00ff',
+    'hsl': 'hsl(300 100% 50.01%)',
+    'lab': 'lab(60.17 93.54 -60.51)',
+    'lch': 'lch(60.17 111.41 327.1)',
+    'lrgb': 'Linear RGB vec(1.00005, 0.00001, 1.00019, 1)',
+    'numbers': '0.7, 0.32, 328.36',
+    'oklab': 'oklab(0.7 0.27 -0.17)',
+    'p3': 'color(display-p3 0.9175 0.2003 0.9676)',
+    'rgb': 'rgb(255, 0, 255)'
+  })
+
+  deepStrictEqual(formatsFor('#ffff00'), {
+    'figmaP3': 'Figma P3 #ffff54ff',
+    'hex': '#ffff00',
+    'hex/rgba': '#ffff00',
+    'hsl': 'hsl(60 100% 50.02%)',
+    'lab': 'lab(97.61 -15.75 93.39)',
+    'lch': 'lch(97.61 94.71 99.57)',
+    'lrgb': 'Linear RGB vec(1.00003, 1.00006, 0.00003, 1)',
+    'numbers': '0.97, 0.21, 109.77',
+    'oklab': 'oklab(0.97 -0.07 0.2)',
+    'p3': 'color(display-p3 1 1 0.331)',
+    'rgb': 'rgb(255, 255, 0)'
+  })
+})
+
+test('formats for near-edge sRGB (#010101, #fefefe)', () => {
+  deepStrictEqual(formatsFor('#010101'), {
+    'figmaP3': 'Figma P3 #010101ff',
+    'hex': '#010101',
+    'hex/rgba': '#010101',
+    'hsl': 'hsl(0 0% 0.39%)',
+    'lab': 'lab(0.27 0 0)',
+    'lch': 'lch(0.27 0 none)',
+    'lrgb': 'Linear RGB vec(0.0003, 0.0003, 0.0003, 1)',
+    'numbers': '0.07, 0, 0',
+    'oklab': 'oklab(0.07 0 0)',
+    'p3': 'color(display-p3 0.0039 0.0039 0.0039)',
+    'rgb': 'rgb(1, 1, 1)'
+  })
+
+  deepStrictEqual(formatsFor('#fefefe'), {
+    'figmaP3': 'Figma P3 #fefefeff',
+    'hex': '#fefefe',
+    'hex/rgba': '#fefefe',
+    'hsl': 'hsl(0 0% 99.6%)',
+    'lab': 'lab(99.65 0 0)',
+    'lch': 'lch(99.65 0 none)',
+    'lrgb': 'Linear RGB vec(0.99103, 0.99103, 0.99103, 1)',
+    'numbers': '1, 0, 0',
+    'oklab': 'oklab(1 0 0)',
+    'p3': 'color(display-p3 0.996 0.996 0.996)',
+    'rgb': 'rgb(254, 254, 254)'
+  })
+})
+
+test('formats for achromatic grays (dark, mid, light)', () => {
+  deepStrictEqual(formatsFor('#404040'), {
+    'figmaP3': 'Figma P3 #404040ff',
+    'hex': '#404040',
+    'hex/rgba': '#404040',
+    'hsl': 'hsl(0 0% 25.1%)',
+    'lab': 'lab(27.09 0 0)',
+    'lch': 'lch(27.09 0 none)',
+    'lrgb': 'Linear RGB vec(0.05127, 0.05127, 0.05127, 1)',
+    'numbers': '0.37, 0, 0',
+    'oklab': 'oklab(0.37 0 0)',
+    'p3': 'color(display-p3 0.251 0.251 0.251)',
+    'rgb': 'rgb(64, 64, 64)'
+  })
+
+  deepStrictEqual(formatsFor('#c0c0c0'), {
+    'figmaP3': 'Figma P3 #c0c0c0ff',
+    'hex': '#c0c0c0',
+    'hex/rgba': '#c0c0c0',
+    'hsl': 'hsl(0 0% 75.29%)',
+    'lab': 'lab(77.7 0 0)',
+    'lch': 'lch(77.7 0 none)',
+    'lrgb': 'Linear RGB vec(0.52712, 0.52712, 0.52712, 1)',
+    'numbers': '0.81, 0, 0',
+    'oklab': 'oklab(0.81 0 0)',
+    'p3': 'color(display-p3 0.7529 0.7529 0.7529)',
+    'rgb': 'rgb(192, 192, 192)'
+  })
+})
+
+test('formats for near-zero and near-full alpha', () => {
+  deepStrictEqual(formatsFor('#ff000001'), {
+    'figmaP3': 'Figma P3 #ea332301',
+    'hex': '#ff000001',
+    'hex/rgba': 'rgba(255, 0, 0, 0.004)',
+    'hsl': 'hsl(359.98 100% 50% / 0.004)',
+    'lab': 'lab(54.3 80.81 69.88 / 0.004)',
+    'lch': 'lch(54.3 106.83 40.85 / 0.004)',
+    'lrgb': 'Linear RGB vec(1.00021, 0, 0.00002, 0.0039)',
+    'numbers': '0.63, 0.26, 29.23, 0',
+    'oklab': 'oklab(0.63 0.22 0.13 / 0.004)',
+    'p3': 'color(display-p3 0.9176 0.2003 0.1387 / 0.004)',
+    'rgb': 'rgba(255, 0, 0, 0.004)'
+  })
+
+  deepStrictEqual(formatsFor('#ff0000fe'), {
+    'figmaP3': 'Figma P3 #ea3323fe',
+    'hex': '#ff0000fe',
+    'hex/rgba': 'rgba(255, 0, 0, 0.996)',
+    'hsl': 'hsl(359.98 100% 50% / 0.996)',
+    'lab': 'lab(54.3 80.81 69.88 / 0.996)',
+    'lch': 'lch(54.3 106.83 40.85 / 0.996)',
+    'lrgb': 'Linear RGB vec(1.00021, 0, 0.00002, 0.9961)',
+    'numbers': '0.63, 0.26, 29.23, 1',
+    'oklab': 'oklab(0.63 0.22 0.13 / 0.996)',
+    'p3': 'color(display-p3 0.9176 0.2003 0.1387 / 0.996)',
+    'rgb': 'rgba(255, 0, 0, 0.996)'
+  })
+})
+
+test('formats for OKLCH corner L=0 (pure black)', () => {
+  deepStrictEqual(formatsFor('oklch(0 0 0)'), {
+    'figmaP3': 'Figma P3 #000000ff',
+    'hex': '#000000',
+    'hex/rgba': '#000000',
+    'hsl': 'hsl(0 0% 0%)',
+    'lab': 'lab(0 0 0)',
+    'lch': 'lch(0 0 none)',
+    'lrgb': 'Linear RGB vec(0, 0, 0, 1)',
+    'numbers': '0, 0, 0',
+    'oklab': 'oklab(0 0 0)',
+    'p3': 'color(display-p3 0 0 0)',
+    'rgb': 'rgb(0, 0, 0)'
+  })
+})
+
+test('formats for OKLCH corner L=1 with chroma (beyond-white)', () => {
+  deepStrictEqual(formatsFor('oklch(1 0.1 180)'), {
+    'figmaP3': 'Figma P3 #c7ffffff',
+    'hex': '#ffffff',
+    'hex/rgba': '#ffffff',
+    'hsl': 'hsl(0 0% 100%)',
+    'lab': 'lab(101.26 -34.49 -0.29)',
+    'lch': 'lch(101.26 34.49 180.48)',
+    'lrgb': 'Linear RGB vec(0.43462, 1.2192, 1.02422, 1)',
+    'numbers': '1, 0.1, 180',
+    'oklab': 'oklab(1 -0.1 0)',
+    'p3': 'color(display-p3 0.7821 1.0806 1.0123)',
+    'rgb': 'rgb(255, 255, 255)'
+  })
+})
+
+test('formats for very low L with non-zero C (spike region)', () => {
+  deepStrictEqual(formatsFor('oklch(0.02 0.05 0)'), {
+    'figmaP3': 'Figma P3 #010000ff',
+    'hex': '#000000',
+    'hex/rgba': '#000000',
+    'hsl': 'hsl(356.92 100% 0.07%)',
+    'lab': 'lab(0 0.31 0.01)',
+    'lch': 'lch(0 0.31 1.15)',
+    'lrgb': 'Linear RGB vec(0.00025, -0.00007, 0, 1)',
+    'numbers': '0.02, 0.05, 0',
+    'oklab': 'oklab(0.02 0.05 0)',
+    'p3': 'color(display-p3 0.0025 -0.0008 0)',
+    'rgb': 'rgb(0, 0, 0)'
+  })
+})
+
+test('formats for P3-only color', () => {
+  deepStrictEqual(formatsFor('oklch(0.7 0.3 140)'), {
+    'figmaP3': 'Figma P3 #45c200ff',
+    'hex': '#14c000',
+    'hex/rgba': '#14c000',
+    'hsl': 'hsl(113.65 100% 37.7%)',
+    'lab': 'lab(68.32 -76.09 119.41)',
+    'lch': 'lch(68.32 141.6 122.51)',
+    'lrgb': 'Linear RGB vec(-0.04709, 0.55678, -0.07598, 1)',
+    'numbers': '0.7, 0.3, 140',
+    'oklab': 'oklab(0.7 -0.23 0.19)',
+    'p3': 'color(display-p3 0.272 0.7591 -0.1886)',
+    'rgb': 'rgb(20, 192, 0)'
+  })
+})
+
+test('formats for Rec2020-only color', () => {
+  deepStrictEqual(formatsFor('oklch(0.7 0.4 140)'), {
+    'figmaP3': 'Figma P3 #00ca00ff',
+    'hex': '#14c000',
+    'hex/rgba': '#14c000',
+    'hsl': 'hsl(113.66 100% 37.7%)',
+    'lab': 'lab(69.09 -101.31 218.07)',
+    'lch': 'lch(69.09 240.46 114.92)',
+    'lrgb': 'Linear RGB vec(-0.16037, 0.61325, -0.15366, 1)',
+    'numbers': '0.7, 0.4, 140',
+    'oklab': 'oklab(0.7 -0.31 0.26)',
+    'p3': 'color(display-p3 -0.1642 0.7903 -0.3462)',
+    'rgb': 'rgb(20, 192, 0)'
+  })
+})
+
+test('formats for out-of-gamut color', () => {
+  deepStrictEqual(formatsFor('oklch(0.5 0.5 30)'), {
+    'figmaP3': 'Figma P3 #ff0000ff',
+    'hex': '#c30000',
+    'hex/rgba': '#c30000',
+    'hsl': 'hsl(0 100% 38.3%)',
+    'lab': 'lab(36.13 162.38 153.26)',
+    'lch': 'lch(36.13 223.29 43.35)',
+    'lrgb': 'Linear RGB vec(1.27928, -0.26564, -0.05632, 1)',
+    'numbers': '0.5, 0.5, 30',
+    'oklab': 'oklab(0.5 0.43 0.25)',
+    'p3': 'color(display-p3 1.0022 -0.5003 -0.2444)',
+    'rgb': 'rgb(195, 0, 0)'
+  })
+})

--- a/test/visible.test.ts
+++ b/test/visible.test.ts
@@ -1,0 +1,115 @@
+import './set-globals.ts'
+
+import { deepStrictEqual, ok } from 'node:assert'
+import { test } from 'node:test'
+
+import { setCurrent } from '../stores/current.ts'
+import { support } from '../stores/support.ts'
+import { visible } from '../stores/visible.ts'
+
+function visibleFor(
+  input: string,
+  p3: boolean,
+  rec2020: boolean
+): ReturnType<typeof visible.get> {
+  support.set({ p3, rec2020 })
+  setCurrent(input)
+  return visible.get()
+}
+
+test('sRGB color: space=srgb regardless of support', () => {
+  for (let p3 of [false, true]) {
+    for (let rec2020 of [false, true]) {
+      let v = visibleFor('#ff0000', p3, rec2020)
+      deepStrictEqual(v.space, 'srgb')
+      deepStrictEqual(v.fallback, 'rgb(255.02, -0.01, 0.07)')
+      deepStrictEqual(v.real, 'rgb(255.02, -0.01, 0.07)')
+      deepStrictEqual(v.color, {
+        alpha: 1,
+        c: 0.2577,
+        h: 29.23,
+        l: 0.628,
+        mode: 'oklch'
+      })
+    }
+  }
+})
+
+test('sRGB color with alpha', () => {
+  let v = visibleFor('#ff000080', false, false)
+  deepStrictEqual(v.space, 'srgb')
+  deepStrictEqual(v.fallback, 'rgba(255.02, -0.01, 0.07, 0.502)')
+  deepStrictEqual(v.real, 'rgba(255.02, -0.01, 0.07, 0.502)')
+  deepStrictEqual(v.color, {
+    alpha: 0.502,
+    c: 0.2577,
+    h: 29.23,
+    l: 0.628,
+    mode: 'oklch'
+  })
+})
+
+test('P3 color with P3 support → real is oklch, color is oklch', () => {
+  let v = visibleFor('oklch(0.6 0.22 145)', true, false)
+  deepStrictEqual(v.space, 'p3')
+  deepStrictEqual(v.fallback, 'rgb(0, 158.78, 0)')
+  deepStrictEqual(v.real, 'oklch(0.6 0.22 145)')
+  deepStrictEqual(v.color, {
+    alpha: 1,
+    c: 0.22,
+    h: 145,
+    l: 0.6,
+    mode: 'oklch'
+  })
+})
+
+test('P3 color without P3 support → real is false, color is rgb fallback', () => {
+  let v = visibleFor('oklch(0.6 0.22 145)', false, false)
+  deepStrictEqual(v.space, 'p3')
+  deepStrictEqual(v.fallback, 'rgb(0, 158.78, 0)')
+  deepStrictEqual(v.real, false)
+  ok(
+    typeof v.color === 'object' && v.color !== null && 'mode' in v.color &&
+      (v.color as { mode: string }).mode === 'rgb'
+  )
+})
+
+test('Rec2020 color with Rec2020 support → real is oklch, color is oklch', () => {
+  let v = visibleFor('oklch(0.6 0.26 145)', false, true)
+  deepStrictEqual(v.space, 'rec2020')
+  deepStrictEqual(v.fallback, 'rgb(0, 159.05, 0)')
+  deepStrictEqual(v.real, 'oklch(0.6 0.26 145)')
+  deepStrictEqual(v.color, {
+    alpha: 1,
+    c: 0.26,
+    h: 145,
+    l: 0.6,
+    mode: 'oklch'
+  })
+})
+
+test('Rec2020 color without Rec2020 support → real is false, color is rgb fallback', () => {
+  let v = visibleFor('oklch(0.6 0.26 145)', true, false)
+  deepStrictEqual(v.space, 'rec2020')
+  deepStrictEqual(v.fallback, 'rgb(0, 159.05, 0)')
+  deepStrictEqual(v.real, false)
+  ok(
+    typeof v.color === 'object' && v.color !== null && 'mode' in v.color &&
+      (v.color as { mode: string }).mode === 'rgb'
+  )
+})
+
+test('out-of-gamut color: space=out, real=false, color is rgb fallback', () => {
+  for (let p3 of [false, true]) {
+    for (let rec2020 of [false, true]) {
+      let v = visibleFor('oklch(0.5 0.5 30)', p3, rec2020)
+      deepStrictEqual(v.space, 'out')
+      deepStrictEqual(v.fallback, 'rgb(195.33, 0, 0)')
+      deepStrictEqual(v.real, false)
+      ok(
+        typeof v.color === 'object' && v.color !== null && 'mode' in v.color &&
+          (v.color as { mode: string }).mode === 'rgb'
+      )
+    }
+  }
+})

--- a/view/chart/index.ts
+++ b/view/chart/index.ts
@@ -1,5 +1,7 @@
+import { colordx } from '@colordx/core'
+
 import { getCleanCtx, initCanvasSize } from '../../lib/canvas.ts'
-import { parse, rgb } from '../../lib/colors.ts'
+import { type Rgb, toCuloriRgb } from '../../lib/colors.ts'
 import { getBorders } from '../../lib/dom.ts'
 import { prepareWorkers } from '../../lib/workers.ts'
 import { reportFreeze, reportPaint } from '../../stores/benchmark.ts'
@@ -85,6 +87,10 @@ initEvents(canvasH)
 
 let startWork = prepareWorkers<PaintData, PaintedData>(PaintWorker)
 
+function parseBorder(css: string): Rgb {
+  return toCuloriRgb(colordx(css).toRgb())
+}
+
 function startWorkForComponent(
   canvas: HTMLCanvasElement,
   type: 'c' | 'h' | 'l',
@@ -92,8 +98,8 @@ function startWorkForComponent(
   chartsToChange: number
 ): void {
   let [cssP3, cssRec2020] = getBorders()
-  let borderP3 = rgb(parse(cssP3)!)
-  let borderRec2020 = rgb(parse(cssRec2020)!)
+  let borderP3 = parseBorder(cssP3)
+  let borderRec2020 = parseBorder(cssRec2020)
 
   let parts: [ImageData, number][] = []
   startWork(

--- a/view/sample/index.ts
+++ b/view/sample/index.ts
@@ -1,4 +1,5 @@
-import { lch, oklch } from '../../lib/colors.ts'
+import { colordx } from '@colordx/core'
+
 import { colorToValue, current } from '../../stores/current.ts'
 import { visible } from '../../stores/visible.ts'
 
@@ -31,6 +32,17 @@ visible.subscribe(({ fallback, real, space }) => {
 
 fallbackNote.addEventListener('click', () => {
   let fallback = visible.get().fallback
-  let color = COLOR_FN === 'lch' ? lch(fallback) : oklch(fallback)
-  current.set(colorToValue(color!))
+  let color =
+    COLOR_FN === 'lch'
+      ? colordx(fallback).toLch()
+      : colordx(fallback).toOklch()
+  current.set(
+    colorToValue({
+      alpha: color.alpha,
+      c: color.c,
+      h: color.h,
+      l: color.l,
+      mode: COLOR_FN
+    })
+  )
 })


### PR DESCRIPTION
Moves all 4 stores (`benchmark`, `current`, `formats`, `visible`), `view/sample`, `view/chart`, and the LCH render hot path off culori with full backward compatability