### PR TITLE
Fix aria-valuenow for intermediate spinbutton input

### DIFF
--- a/test/field.test.ts
+++ b/test/field.test.ts
@@ -1,0 +1,78 @@
+import './set-globals.ts'
+
+import { strictEqual } from 'node:assert'
+import { test } from 'node:test'
+
+import { setSpinbuttonValue, syncSpinbuttonAria } from '../view/field/aria.ts'
+
+function createInput(value: string): HTMLInputElement {
+  let input = document.createElement('input')
+  input.setAttribute('role', 'spinbutton')
+  input.value = value
+  return input
+}
+
+test('sets aria-valuenow for numeric text', () => {
+  let input = createInput('0.25')
+
+  syncSpinbuttonAria(input)
+
+  strictEqual(input.getAttribute('aria-valuenow'), '0.25')
+  strictEqual(input.hasAttribute('aria-valuetext'), false)
+})
+
+test('removes aria-valuenow for trailing operators', () => {
+  let input = createInput('1+')
+
+  syncSpinbuttonAria(input)
+
+  strictEqual(input.hasAttribute('aria-valuenow'), false)
+  strictEqual(input.getAttribute('aria-valuetext'), '1+')
+})
+
+test('removes aria-valuenow for incomplete decimals', () => {
+  let input = createInput('.')
+
+  syncSpinbuttonAria(input)
+
+  strictEqual(input.hasAttribute('aria-valuenow'), false)
+  strictEqual(input.getAttribute('aria-valuetext'), '.')
+})
+
+test('clears aria value attributes for empty input', () => {
+  let input = createInput('')
+  input.setAttribute('aria-valuenow', '1')
+  input.setAttribute('aria-valuetext', '1')
+
+  syncSpinbuttonAria(input)
+
+  strictEqual(input.hasAttribute('aria-valuenow'), false)
+  strictEqual(input.hasAttribute('aria-valuetext'), false)
+})
+
+test('switches from aria-valuetext to aria-valuenow after expression resolves', () => {
+  let input = createInput('1/2')
+
+  syncSpinbuttonAria(input)
+  strictEqual(input.hasAttribute('aria-valuenow'), false)
+  strictEqual(input.getAttribute('aria-valuetext'), '1/2')
+
+  input.value = '0.5'
+  syncSpinbuttonAria(input)
+
+  strictEqual(input.getAttribute('aria-valuenow'), '0.5')
+  strictEqual(input.hasAttribute('aria-valuetext'), false)
+})
+
+test('setSpinbuttonValue replaces stale text with the committed value', () => {
+  let input = createInput('2')
+
+  syncSpinbuttonAria(input)
+  strictEqual(input.getAttribute('aria-valuenow'), '2')
+
+  setSpinbuttonValue(input, 1)
+
+  strictEqual(input.value, '1')
+  strictEqual(input.getAttribute('aria-valuenow'), '1')
+  strictEqual(input.hasAttribute('aria-valuetext'), false)
+})

--- a/view/card/index.ts
+++ b/view/card/index.ts
@@ -2,6 +2,7 @@ import { clean } from '../../lib/colors.ts'
 import { computeExpression, cycleByWheel, parseValue } from '../../lib/math.ts'
 import { current, onCurrentChange } from '../../stores/current.ts'
 import { showCharts, showRec2020 } from '../../stores/settings.ts'
+import { setSpinbuttonValue, syncSpinbuttonAria } from '../field/aria.ts'
 import { setInvalid, type SpinEvent } from '../field/index.ts'
 
 interface MetaSpinInput {
@@ -37,6 +38,8 @@ function initInput(type: 'a' | 'c' | 'h' | 'l'): HTMLInputElement {
   let text = card.querySelector<HTMLInputElement>('[role=spinbutton]')!
   let bindedClamp = clampInRange(type === 'h', type === 'h' ? 2 : 4)
 
+  syncSpinbuttonAria(text)
+
   text.addEventListener('change', () => {
     let { max, min } = getInputMeta(text)
 
@@ -51,11 +54,12 @@ function initInput(type: 'a' | 'c' | 'h' | 'l'): HTMLInputElement {
     let angleInRange = bindedClamp(computedExpression, { max, min })
 
     current.setKey(type, angleInRange)
-    text.setAttribute('aria-valuenow', String(angleInRange))
 
     if (angleInRange === prevValue && text.value !== String(angleInRange)) {
       text.value = String(angleInRange)
     }
+
+    syncSpinbuttonAria(text)
   })
 
   text.addEventListener('spin', (e: SpinEvent) => {
@@ -71,7 +75,7 @@ function initInput(type: 'a' | 'c' | 'h' | 'l'): HTMLInputElement {
     let parsedValue = bindedClamp(value, { max, min })
 
     current.setKey(type, parsedValue)
-    text.setAttribute('aria-valuenow', String(parsedValue))
+    setSpinbuttonValue(text, parsedValue)
   })
 
   return text
@@ -84,16 +88,16 @@ let textA = initInput('a')
 
 onCurrentChange({
   alpha(value) {
-    textA.value = String(value)
+    setSpinbuttonValue(textA, value)
   },
   c(value) {
-    textC.value = String(value)
+    setSpinbuttonValue(textC, value)
   },
   h(value) {
-    textH.value = String(value)
+    setSpinbuttonValue(textH, value)
   },
   l(value) {
-    textL.value = String(value)
+    setSpinbuttonValue(textL, value)
   }
 })
 

--- a/view/field/aria.ts
+++ b/view/field/aria.ts
@@ -1,0 +1,27 @@
+export function syncSpinbuttonAria(input: HTMLInputElement): void {
+  let rawValue = input.value.trim()
+
+  if (rawValue === '') {
+    input.removeAttribute('aria-valuenow')
+    input.removeAttribute('aria-valuetext')
+    return
+  }
+
+  let numericValue = Number(rawValue)
+
+  if (Number.isFinite(numericValue)) {
+    input.setAttribute('aria-valuenow', rawValue)
+    input.removeAttribute('aria-valuetext')
+  } else {
+    input.removeAttribute('aria-valuenow')
+    input.setAttribute('aria-valuetext', rawValue)
+  }
+}
+
+export function setSpinbuttonValue(
+  input: HTMLInputElement,
+  value: number | string
+): void {
+  input.value = String(value)
+  syncSpinbuttonAria(input)
+}

--- a/view/field/index.ts
+++ b/view/field/index.ts
@@ -1,5 +1,6 @@
 import { isInput } from '../../lib/dom.ts'
 import { convertKey } from '../../lib/hotkeys.ts'
+import { syncSpinbuttonAria } from './aria.ts'
 
 let fields = document.querySelectorAll<HTMLDivElement>('.field')
 let meta = document.querySelector<HTMLMetaElement>('meta[name=viewport]')!
@@ -192,7 +193,7 @@ function useSpinButton(input: HTMLInputElement): void {
       }
     }
 
-    input.setAttribute('aria-valuenow', input.value)
+    syncSpinbuttonAria(input)
   }
 
   increase.addEventListener('mousedown', onPressed)


### PR DESCRIPTION
Closes #208

Fix `aria-valuenow` for intermediate spinbutton input.

- keep `aria-valuenow` numeric-only
- use `aria-valuetext` while the input is still an expression
- write the clamped value back into the field on spin so boundary no-ops do not leave stale text behind

Tests:
- add regression tests for numeric, empty, expression, and boundary spin cases

Manual checks:
- tested in Firefox
- tested with VoiceOver in Firefox
