### PR TITLE
fix voiceover navigation in chromium

### DIFF
--- a/test/field.test.ts
+++ b/test/field.test.ts
@@ -5,11 +5,52 @@ import { test } from 'node:test'
 
 import { setSpinbuttonValue, syncSpinbuttonAria } from '../view/field/aria.ts'
 
+document.head.innerHTML = '<meta name="viewport" content="width=device-width">'
+document.body.innerHTML = `
+  <div class="field">
+    <kbd>l</kbd>
+    <input
+      class="field_input"
+      pattern="^[0-9+\\/*.\\-]+$"
+      role="spinbutton"
+      value="50"
+    >
+    <button></button>
+    <button></button>
+  </div>
+  <div class="field">
+    <kbd>c</kbd>
+    <input
+      class="field_input"
+      pattern="^[0-9+\\/*.\\-]+$"
+      role="spinbutton"
+      value="0.1"
+    >
+    <button></button>
+    <button></button>
+  </div>
+`
+
+await import('../view/field/index.ts')
+
 function createInput(value: string): HTMLInputElement {
   let input = document.createElement('input')
   input.setAttribute('role', 'spinbutton')
   input.value = value
   return input
+}
+
+function getFieldInputs(): NodeListOf<HTMLInputElement> {
+  let inputs = document.querySelectorAll<HTMLInputElement>('.field_input')
+
+  inputs[0].value = '50'
+  inputs[0].setSelectionRange(inputs[0].value.length, inputs[0].value.length)
+  inputs[0].blur()
+  inputs[1].value = '0.1'
+  inputs[1].setSelectionRange(inputs[1].value.length, inputs[1].value.length)
+  inputs[1].blur()
+
+  return inputs
 }
 
 test('sets aria-valuenow for numeric text', () => {
@@ -75,4 +116,85 @@ test('setSpinbuttonValue replaces stale text with the committed value', () => {
   strictEqual(input.value, '1')
   strictEqual(input.getAttribute('aria-valuenow'), '1')
   strictEqual(input.hasAttribute('aria-valuetext'), false)
+})
+
+test('does not select field text on plain focus', () => {
+  let inputs = getFieldInputs()
+  let lightness = inputs[0]
+  lightness.setSelectionRange(1, 1)
+  lightness.focus()
+
+  strictEqual(lightness.selectionStart, 1)
+  strictEqual(lightness.selectionEnd, 1)
+})
+
+test('clears field text selection on blur', () => {
+  let inputs = getFieldInputs()
+  let lightness = inputs[0]
+  lightness.focus()
+  lightness.select()
+  lightness.blur()
+
+  strictEqual(lightness.selectionStart, lightness.value.length)
+  strictEqual(lightness.selectionEnd, lightness.value.length)
+})
+
+test('selects field text on pointer focus', () => {
+  let inputs = getFieldInputs()
+  let chroma = inputs[1]
+  chroma.setSelectionRange(1, 1)
+  chroma.dispatchEvent(
+    new window.MouseEvent('mousedown', { bubbles: true, button: 0 })
+  )
+
+  strictEqual(chroma.selectionStart, 0)
+  strictEqual(chroma.selectionEnd, chroma.value.length)
+})
+
+test('keeps caret position on pointer interaction inside focused field', () => {
+  let inputs = getFieldInputs()
+  let chroma = inputs[1]
+  chroma.focus()
+  chroma.setSelectionRange(1, 1)
+  chroma.dispatchEvent(
+    new window.MouseEvent('mousedown', { bubbles: true, button: 0 })
+  )
+
+  strictEqual(chroma.selectionStart, 1)
+  strictEqual(chroma.selectionEnd, 1)
+})
+
+test('selects field text on app hotkey focus', () => {
+  let inputs = getFieldInputs()
+  let lightness = inputs[0]
+  lightness.setSelectionRange(1, 1)
+  document.body.dispatchEvent(
+    new window.KeyboardEvent('keyup', { bubbles: true, code: 'KeyL', key: 'l' })
+  )
+
+  strictEqual(document.activeElement, lightness)
+  strictEqual(lightness.selectionStart, 0)
+  strictEqual(lightness.selectionEnd, lightness.value.length)
+})
+
+test('selects field text on in-field hotkey focus', () => {
+  let inputs = getFieldInputs()
+  let lightness = inputs[0]
+  let chroma = inputs[1]
+  lightness.focus()
+  lightness.select()
+  chroma.setSelectionRange(1, 1)
+  lightness.dispatchEvent(
+    new window.KeyboardEvent('keydown', {
+      bubbles: true,
+      code: 'KeyC',
+      key: 'c'
+    })
+  )
+
+  strictEqual(document.activeElement, chroma)
+  strictEqual(lightness.selectionStart, lightness.value.length)
+  strictEqual(lightness.selectionEnd, lightness.value.length)
+  strictEqual(chroma.selectionStart, 0)
+  strictEqual(chroma.selectionEnd, chroma.value.length)
 })

--- a/view/field/index.ts
+++ b/view/field/index.ts
@@ -40,21 +40,26 @@ export function toggleWarning(input: HTMLInputElement, toggle: boolean): void {
   input.classList.toggle('is-warning', toggle)
 }
 
-// The hack to prevent loosing selected text on click
-function onMouseUp(e: MouseEvent): void {
-  e.preventDefault()
-  let input = e.target as HTMLInputElement
-  input.removeEventListener('mouseup', onMouseUp)
+function focusAndSelect(input: HTMLInputElement): void {
+  let wasFocused = document.activeElement === input
+  input.focus()
+  if (!wasFocused) {
+    input.select()
+  }
 }
 
-function onFocus(e: FocusEvent): void {
-  let input = e.target as HTMLInputElement
-  input.select()
+function onFieldMouseDown(e: MouseEvent): void {
+  if (e.button !== 0) return
+  let input = e.currentTarget as HTMLInputElement
+  if (document.activeElement === input) return
 
-  input.addEventListener('mouseup', onMouseUp)
-  setTimeout(() => {
-    input.addEventListener('mouseup', onMouseUp)
-  }, 500)
+  e.preventDefault()
+  focusAndSelect(input)
+}
+
+function onFieldBlur(e: FocusEvent): void {
+  let input = e.target as HTMLInputElement
+  input.setSelectionRange(input.value.length, input.value.length)
 }
 
 function isSpecial(e: KeyboardEvent): boolean {
@@ -65,7 +70,8 @@ let hotkeys: Partial<Record<string, HTMLInputElement>> = {}
 
 for (let field of fields) {
   let input = field.querySelector<HTMLInputElement>('input')!
-  input.addEventListener('focus', onFocus)
+  input.addEventListener('mousedown', onFieldMouseDown)
+  input.addEventListener('blur', onFieldBlur)
 
   if (input.getAttribute('role') === 'spinbutton') {
     useSpinButton(input)
@@ -75,7 +81,7 @@ for (let field of fields) {
   hotkeys[hotkey] = input
 }
 
-function findNextFocus(e: KeyboardEvent): HTMLElement | undefined {
+function findNextFocus(e: KeyboardEvent): HTMLInputElement | undefined {
   let key = convertKey(e)
 
   return hotkeys[key]
@@ -84,7 +90,10 @@ function findNextFocus(e: KeyboardEvent): HTMLElement | undefined {
 window.addEventListener('keyup', e => {
   if (isSpecial(e)) return
   if (e.target === document.body) {
-    findNextFocus(e)?.focus()
+    let next = findNextFocus(e)
+    if (next) {
+      focusAndSelect(next)
+    }
   } else if (isInput(e.target) && e.key === 'Escape') {
     e.target.blur()
   }
@@ -159,7 +168,7 @@ function useSpinButton(input: HTMLInputElement): void {
     let next = findNextFocus(e)
     if (next) {
       e.preventDefault()
-      next.focus()
+      focusAndSelect(next)
     }
 
     if (e.key === 'ArrowUp') {
@@ -179,8 +188,6 @@ function useSpinButton(input: HTMLInputElement): void {
   }
 
   function onInput(e: Event): void {
-    input.removeEventListener('mouseup', onMouseUp)
-
     if (e instanceof InputEvent) {
       let value = input.value
       let caretPosition = input.selectionStart!


### PR DESCRIPTION
closes #207

the problem was caused by selecting field text on every focus.

removing `select()` from focus fixes voiceover navigation in chromium, but it also removes a useful ux: users could click a field or press app hotkey and replace the whole value right away.

this pr keeps both cases:

- regular focus does not select text
- mouse entry selects the whole value
- app hotkeys select the whole value

so voiceover can move through l/c/h/alpha fields with `ctrl+opt+cmd+j`, but normal quick field editing still works.

tests:
- added regression tests for focus, blur, mouse entry, and hotkeys

manual checks:
- tested in chromium + voiceover
- checked forward/backward form-control navigation
- checked mouse entry and field hotkeys

rec from chromium w/ a fix

https://github.com/user-attachments/assets/e678bb46-356b-40e0-a50b-2d08c12f6057

